### PR TITLE
update code to prevent typescript 2.4 errors

### DIFF
--- a/app/src/main/admin/stores/AdminAuthStore.ts
+++ b/app/src/main/admin/stores/AdminAuthStore.ts
@@ -1,5 +1,6 @@
 import { AuthStateBase, AuthStore, AuthStoreBaseInterface } from "../../shared/stores/AuthStoreBase";
 import { alt } from "../../shared/alt";
+import StoreModel = AltJS.StoreModel;
 
 class AdminAuthStore extends AuthStore<AuthStateBase, AuthStoreBaseInterface<AuthStateBase>> {
     initialState(): AuthStateBase {
@@ -7,4 +8,4 @@ class AdminAuthStore extends AuthStore<AuthStateBase, AuthStoreBaseInterface<Aut
     }
 }
 
-export const adminAuthStore = alt.createStore<AuthStateBase>(AdminAuthStore) as AuthStoreBaseInterface<AuthStateBase>;
+export const adminAuthStore = alt.createStore<AuthStateBase>(AdminAuthStore as StoreModel<AuthStateBase>) as AuthStoreBaseInterface<AuthStateBase>;

--- a/app/src/main/admin/stores/GroupStore.ts
+++ b/app/src/main/admin/stores/GroupStore.ts
@@ -6,6 +6,7 @@ import { modellingGroupActions } from "../actions/ModellingGroupActions";
 import { RemoteContent } from "../../shared/models/RemoteContent";
 import { ModellingGroupSource } from "../sources/ModellingGroupSource";
 import { ILookup } from "../../shared/models/Lookup";
+import StoreModel = AltJS.StoreModel;
 
 export interface GroupState extends RemoteContent {
     groups: ModellingGroup[];
@@ -78,4 +79,4 @@ export class GroupStore extends AbstractStore<GroupState, Interface> {
     }
 }
 
-export const groupStore = alt.createStore<GroupState>(GroupStore) as Interface;
+export const groupStore = alt.createStore<GroupState>(GroupStore as StoreModel<GroupState>) as Interface;

--- a/app/src/main/admin/stores/UserStore.ts
+++ b/app/src/main/admin/stores/UserStore.ts
@@ -4,6 +4,7 @@ import { User } from "../../shared/models/Generated";
 import { UserSource } from "../sources/UserSource";
 import { userActions } from "../actions/UserActions";
 import { RemoteContent } from "../../shared/models/RemoteContent";
+import StoreModel = AltJS.StoreModel;
 
 export interface UserStoreState extends RemoteContent {
     users: User[];
@@ -43,4 +44,4 @@ class UserStore extends AbstractStore<UserStoreState, UserStoreInterface> {
     }
 }
 
-export const userStore = alt.createStore<UserStoreState>(UserStore) as UserStoreInterface;
+export const userStore = alt.createStore<UserStoreState>(UserStore as StoreModel<UserStoreState>) as UserStoreInterface;

--- a/app/src/main/contrib/stores/ContribAuthStore.ts
+++ b/app/src/main/contrib/stores/ContribAuthStore.ts
@@ -4,6 +4,7 @@ import { mainStore } from "./MainStore";
 import { ModellingGroup } from "../../shared/models/Generated";
 import { modellingGroupActions } from "../actions/ModellingGroupActions";
 import { AuthStateBase, AuthStore, AuthStoreBaseInterface } from "../../shared/stores/AuthStoreBase";
+import StoreModel = AltJS.StoreModel;
 
 export interface ContribAuthState extends AuthStateBase {
     modellingGroupIds: string[];
@@ -55,4 +56,6 @@ class ContribAuthStore extends AuthStore<ContribAuthState, ContribAuthStoreInter
     }
 }
 
-export const contribAuthStore = alt.createStore<ContribAuthState>(ContribAuthStore) as ContribAuthStoreInterface;
+export const contribAuthStore =
+    alt.createStore<ContribAuthState>(ContribAuthStore as StoreModel<ContribAuthState>) as
+        ContribAuthStoreInterface;

--- a/app/src/main/contrib/stores/MainStore.ts
+++ b/app/src/main/contrib/stores/MainStore.ts
@@ -10,6 +10,7 @@ import { modellingGroupActions } from "../actions/ModellingGroupActions";
 import { DiseaseSource } from "../sources/DiseaseSource";
 import { ModellingGroupSource } from "../sources/ModellingGroupSource";
 import { doNothing } from "../../shared/Helpers";
+import StoreModel = AltJS.StoreModel;
 
 export interface MainState extends RemoteContent {
     diseases: ILoadable<Disease>;
@@ -82,4 +83,4 @@ class MainStore extends AbstractStore<MainState, Interface> {
     }
 }
 
-export const mainStore = alt.createStore<MainState>(MainStore) as Interface;
+export const mainStore = alt.createStore<MainState>(MainStore as StoreModel<MainState>) as Interface;

--- a/app/src/main/contrib/stores/ResponsibilityStore.ts
+++ b/app/src/main/contrib/stores/ResponsibilityStore.ts
@@ -15,6 +15,7 @@ import { TouchstoneSource } from "../sources/TouchstoneSource";
 import { CoverageSetSource } from "../sources/CoverageSetSource";
 import { CoverageTokenSource } from "../sources/CoverageTokenSource";
 import { mainStore } from "./MainStore";
+import StoreModel = AltJS.StoreModel;
 
 export interface ResponsibilityState extends RemoteContent {
     touchstones: Array<Touchstone>;
@@ -152,4 +153,5 @@ class ResponsibilityStore extends AbstractStore<ResponsibilityState, Responsibil
     }
 }
 
-export const responsibilityStore = <ResponsibilityStoreInterface>alt.createStore<ResponsibilityState>(ResponsibilityStore);
+export const responsibilityStore =
+    <ResponsibilityStoreInterface>alt.createStore<ResponsibilityState>(ResponsibilityStore as StoreModel<ResponsibilityState>);

--- a/app/src/main/shared/stores/NotificationStore.ts
+++ b/app/src/main/shared/stores/NotificationStore.ts
@@ -3,6 +3,7 @@ import { MessageType, Notification, notificationActions } from "../actions/Notif
 import { alt } from "../alt";
 import { authActions, LogInProperties } from "../actions/AuthActions";
 import { appSettings, settings } from "../Settings";
+import StoreModel = AltJS.StoreModel;
 
 export interface NotificationState {
     errors: string[];
@@ -69,4 +70,6 @@ class NotificationStore extends AbstractStore<NotificationState, AltJS.AltStore<
     }
 }
 
-export const notificationStore = alt.createStore<NotificationState>(NotificationStore) as AltJS.AltStore<NotificationState>;
+export const notificationStore =
+    alt.createStore<NotificationState>(NotificationStore as StoreModel<NotificationState>) as
+    AltJS.AltStore<NotificationState>;


### PR DESCRIPTION
See documentation on Typescript 2.4 new concept of 'weak types':
https://github.com/Microsoft/TypeScript/wiki/Breaking-Changes#weak

The AltJs interface `StoreModel<>` is a 'weak type'. To avoid errors we can use an explicit cast of our stores to this interface when calling `alt.createStore`.