### PR TITLE
Catch exceptions properly in the afterWait helper

### DIFF
--- a/app/src/test/admin/components/ModellingGroups/SingleGroup/GroupAdminPageTests.tsx
+++ b/app/src/test/admin/components/ModellingGroups/SingleGroup/GroupAdminPageTests.tsx
@@ -28,7 +28,7 @@ describe("GroupAdminPage", () => {
         checkAsync(done, (afterWait) => {
             expect(fetchGroups.called).to.equal(true, "Expected groupStore.fetchGroups to be triggered");
             expect(fetchUsers.called).to.equal(true, "Expected userStore.fetchUsers to be triggered");
-            afterWait(() => {
+            afterWait(done, () => {
                 expectOneAction(dispatchSpy, { action: "ModellingGroupActions.setCurrentGroup", payload: "gId" });
                 expect(fetchGroupDetails.called).to.equal(true, "Expected groupStore.fetchGroupDetails to be triggered");
             });

--- a/app/src/test/admin/components/ModellingGroups/SingleGroup/ViewModellingGroupDetailsPageTests.tsx
+++ b/app/src/test/admin/components/ModellingGroups/SingleGroup/ViewModellingGroupDetailsPageTests.tsx
@@ -28,7 +28,7 @@ describe("ViewModelingGroupDetailsPage", () => {
         checkAsync(done, (afterWait) => {
             expect(fetchGroups.called).to.equal(true, "Expected groupStore.fetchGroups to be triggered");
             expect(fetchUsers.called).to.equal(true, "Expected userStore.fetchUsers to be triggered");
-            afterWait(() => {
+            afterWait(done, () => {
                 expectOneAction(dispatchSpy, { action: "ModellingGroupActions.setCurrentGroup", payload: "gId" });
                 expect(fetchGroupDetails.called).to.equal(true, "Expected groupStore.fetchGroupDetails to be triggered");
             });

--- a/app/src/test/contrib/components/ChooseAction/ChooseActionPageTests.tsx
+++ b/app/src/test/contrib/components/ChooseAction/ChooseActionPageTests.tsx
@@ -22,7 +22,7 @@ describe("ChooseActionPage", () => {
         sandbox.mount(<ChooseActionPage location={ location } />);
         checkAsync(done, (afterWait) => {
             expect(fetchTouchstones.called).to.equal(true, "Expected responsibilityStore.fetchTouchstones to be called");
-            afterWait(() => {
+            afterWait(done, () => {
                 expectOneAction(spy, {
                     action: "ModellingGroupActions.setCurrentModellingGroup",
                     payload: "gId"

--- a/app/src/test/contrib/components/Responsibilities/DownloadCoveragePageTests.tsx
+++ b/app/src/test/contrib/components/Responsibilities/DownloadCoveragePageTests.tsx
@@ -35,10 +35,10 @@ describe('DownloadCoveragePage', () => {
         checkAsync(done, (afterWait) => {
             expectOneAction(spy, { action: "ModellingGroupActions.setCurrentModellingGroup", payload: "group-1" }, 0);
             expect(fetchTouchstones.called).to.equal(true, "Expected fetchTouchstones to be called");
-            afterWait(() => {
+            afterWait(done, () => {
                 expectOneAction(spy, { action: "TouchstoneActions.setCurrentTouchstone", payload: "touchstone-1" }, 1);
                 expect(fetchResponsibilities.called).to.equal(true, "Expected fetchResponsibilities to be called");
-                afterWait(() => {
+                afterWait(done, () => {
                     expectOneAction(spy, { action: "ResponsibilityActions.setCurrentResponsibility", payload: "scenario-1" }, 2);
                     expect(fetchCoverageSets.called).to.be.equal(true, "Expected fetchCoverageSets to be called");
                     expect(fetchOneTimeCoverageToken.called).to.equal(true, "Expected fetchOneTimeCoverageToken to be called");

--- a/app/src/test/contrib/components/Responsibilities/ResponsibilityOverviewPageTests.tsx
+++ b/app/src/test/contrib/components/Responsibilities/ResponsibilityOverviewPageTests.tsx
@@ -34,7 +34,7 @@ describe('ResponsibilityOverviewPage', () => {
         checkAsync(done, (afterWait) => {
             expectOneAction(spy, { action: "ModellingGroupActions.setCurrentModellingGroup", payload: "group-id" }, 0);
             expect(fetchTouchstones.called).to.equal(true, "Expected fetchTouchstones to be called");
-            afterWait(() => {
+            afterWait(done, () => {
                 expectOneAction(spy, { action: "TouchstoneActions.setCurrentTouchstone", payload: "touchstone-id" }, 1);
                 expect(fetchResponsibilities.called).to.equal(true, "Expected fetchResponsibilities to be called");
             });

--- a/app/src/test/testHelpers.ts
+++ b/app/src/test/testHelpers.ts
@@ -1,7 +1,11 @@
-type AfterWaitCallback = (then: () => void) => void;
+type AfterWaitCallback = (done: DoneCallback, then: () => void) => void;
 
-function afterWait(then: () => void) {
-    setTimeout(then);
+function afterWait(done: DoneCallback, then: () => void) {
+    try {
+        setTimeout(then);
+    } catch (e) {
+        done(e);
+    }
 }
 
 export function checkAsync(done: DoneCallback, checks: (afterWait: AfterWaitCallback) => void) {


### PR DESCRIPTION
We had a problem where, because of the `setTimeout` in `afterWait`, exceptions thrown were not caught by the `try...catch` statement in `checkAsync`. So we also have to wrap the body of the `afterWait` in a `try...catch`.