### PR TITLE
Stopping calling loadables lookups.

### DIFF
--- a/app/src/main/contrib/stores/Loadable.ts
+++ b/app/src/main/contrib/stores/Loadable.ts
@@ -6,14 +6,14 @@ export interface ILoadable<T> {
     loaded: boolean;
 }
 
-export function emptyLookup<T>(): ILoadable<T> {
+export function emptyLoadable<T>(): ILoadable<T> {
     return {
         content: null,
         loaded: false
     };
 }
 
-export function makeLookup<T extends HasId>(items: T[]) {
+export function makeLoadable<T extends HasId>(items: T[]) {
     const content: { [index: string]: T } = {};
     if (items) {
         items.forEach(x => {
@@ -26,7 +26,7 @@ export function makeLookup<T extends HasId>(items: T[]) {
     };
 }
 
-export function getFromLookup<T>(lookup: ILoadable<T>, index: string) {
+export function getFromLoadable<T>(lookup: ILoadable<T>, index: string) {
     if (lookup.loaded) {
         if (lookup.content.hasOwnProperty(index)) {
             return lookup.content[index];

--- a/app/src/main/contrib/stores/Loadable.ts
+++ b/app/src/main/contrib/stores/Loadable.ts
@@ -1,5 +1,5 @@
 import { HasId } from "../models/HasId"
-import { ILookup } from "../../shared/models/Lookup";
+import { getFromLookup, ILookup } from "../../shared/models/Lookup";
 
 export interface ILoadable<T> {
     content: ILookup<T>;
@@ -28,11 +28,7 @@ export function makeLoadable<T extends HasId>(items: T[]) {
 
 export function getFromLoadable<T>(lookup: ILoadable<T>, index: string) {
     if (lookup.loaded) {
-        if (lookup.content.hasOwnProperty(index)) {
-            return lookup.content[index];
-        } else {
-            return null;
-        }
+        return getFromLookup(lookup.content, index);
     } else {
         console.warn(`Attempted to retrieve '${index}' from unloaded lookup`);
         return null;

--- a/app/src/main/contrib/stores/MainStore.ts
+++ b/app/src/main/contrib/stores/MainStore.ts
@@ -2,7 +2,7 @@ import alt from "../../shared/alt";
 import * as AltJS from "alt";
 import { AbstractStore } from "../../shared/stores/AbstractStore";
 import { Disease, ModellingGroup } from "../../shared/models/Generated";
-import { emptyLookup, getFromLookup, ILoadable, makeLookup } from "./Loadable";
+import { emptyLoadable, getFromLoadable, ILoadable, makeLoadable } from "./Loadable";
 import { diseaseActions } from "../actions/DiseaseActions";
 import { RemoteContent } from "../../shared/models/RemoteContent";
 import { responsibilityStore } from "./ResponsibilityStore";
@@ -31,8 +31,8 @@ interface Interface extends AltJS.AltStore<MainState> {
 
 export function initialMainState(): MainState {
     return {
-        diseases: emptyLookup<Disease>(),
-        modellingGroups: emptyLookup<ModellingGroup>(),
+        diseases: emptyLoadable<Disease>(),
+        modellingGroups: emptyLoadable<ModellingGroup>(),
         ready: false
     };
 }
@@ -51,8 +51,8 @@ class MainStore extends AbstractStore<MainState, Interface> {
         this.registerAsync(new DiseaseSource());
         this.registerAsync(new ModellingGroupSource());
         this.exportPublicMethods({
-            getDiseaseById: id => getFromLookup(this.diseases, id),
-            getGroupById: id => getFromLookup(this.modellingGroups, id),
+            getDiseaseById: id => getFromLoadable(this.diseases, id),
+            getGroupById: id => getFromLoadable(this.modellingGroups, id),
             load: () => {
                 this.getInstance().fetchDiseases().catch(doNothing);
                 this.getInstance().fetchModellingGroups().catch(doNothing);
@@ -65,12 +65,12 @@ class MainStore extends AbstractStore<MainState, Interface> {
     }
 
     handleDiseases(diseases: Array<Disease>) {
-        this.diseases = makeLookup(diseases);
+        this.diseases = makeLoadable(diseases);
         this.checkReadiness();
     }
 
     handleModellingGroups(groups: Array<ModellingGroup>) {
-        this.modellingGroups = makeLookup(groups);
+        this.modellingGroups = makeLoadable(groups);
         this.checkReadiness();
     }
 

--- a/app/src/main/shared/models/Lookup.ts
+++ b/app/src/main/shared/models/Lookup.ts
@@ -1,1 +1,9 @@
 export type ILookup<T> = { [index: string]: T };
+
+export function getFromLookup<T>(lookup: ILookup<T>, index: string): T {
+    if (lookup.hasOwnProperty(index)) {
+        return lookup[index];
+    } else {
+        return null;
+    }
+}

--- a/app/src/test/contrib/models/LoadableTests.ts
+++ b/app/src/test/contrib/models/LoadableTests.ts
@@ -1,13 +1,13 @@
 import { expect } from "chai";
 
-import { emptyLookup, getFromLookup, makeLookup } from "../../../main/contrib/stores/Loadable";
+import { emptyLoadable, getFromLoadable, makeLoadable } from "../../../main/contrib/stores/Loadable";
 import { mockDisease } from "../../mocks/mockModels";
 import { Disease } from "../../../main/shared/models/Generated";
 
 describe("Loadable", () => {
     it("can make lookup from array", () => {
         const diseases = [ mockDisease({ id: "d0" }), mockDisease({ id: "d1" }) ];
-        const x = makeLookup(diseases);
+        const x = makeLoadable(diseases);
         expect(x).to.eql({
             content: {
                 d0: diseases[0],
@@ -17,19 +17,19 @@ describe("Loadable", () => {
         });
     });
 
-    it("getFromLookup returns null if lookup is unloaded", () => {
-        const x = emptyLookup<Disease>();
-        expect(getFromLookup(x, "d0")).to.be.null;
+    it("getFromLoadable returns null if lookup is unloaded", () => {
+        const x = emptyLoadable<Disease>();
+        expect(getFromLoadable(x, "d0")).to.be.null;
     });
 
-    it("getFromLookup returns null if key doesn't exist", () => {
-        const x = makeLookup([ mockDisease({ id: "d0" }) ]);
-        expect(getFromLookup(x, "d1")).to.be.null;
+    it("getFromLoadable returns null if key doesn't exist", () => {
+        const x = makeLoadable([ mockDisease({ id: "d0" }) ]);
+        expect(getFromLoadable(x, "d1")).to.be.null;
     });
 
-    it("getFromLookup returns object with matching key", () => {
+    it("getFromLoadable returns object with matching key", () => {
         const disease = mockDisease({ id: "d0" });
-        const x = makeLookup([ disease ]);
-        expect(getFromLookup(x, "d0")).to.equal(disease);
+        const x = makeLoadable([ disease ]);
+        expect(getFromLoadable(x, "d0")).to.equal(disease);
     });
 });

--- a/app/src/test/contrib/stores/MainStoreTests.ts
+++ b/app/src/test/contrib/stores/MainStoreTests.ts
@@ -6,7 +6,7 @@ import { mockDisease, mockModellingGroup } from "../../mocks/mockModels";
 import { mainStore } from "../../../main/contrib/stores/MainStore";
 import { diseaseActions } from "../../../main/contrib/actions/DiseaseActions";
 import { Disease, ModellingGroup } from "../../../main/shared/models/Generated";
-import { emptyLookup } from "../../../main/contrib/stores/Loadable";
+import { emptyLoadable } from "../../../main/contrib/stores/Loadable";
 import {modellingGroupActions} from "../../../main/shared/actions/ModellingGroupActions";
 
 describe("MainStore", () => {
@@ -25,8 +25,8 @@ describe("MainStore", () => {
         const state = mainStore.getState();
         expect(state).to.eql({
             ready: false,
-            diseases: emptyLookup<Disease>(),
-            modellingGroups: emptyLookup<ModellingGroup>()
+            diseases: emptyLoadable<Disease>(),
+            modellingGroups: emptyLoadable<ModellingGroup>()
         });
     });
 
@@ -45,7 +45,7 @@ describe("MainStore", () => {
                     d2: disease2,
                 }
             },
-            modellingGroups: emptyLookup<ModellingGroup>()
+            modellingGroups: emptyLoadable<ModellingGroup>()
         });
     });
 
@@ -57,7 +57,7 @@ describe("MainStore", () => {
         const state = mainStore.getState();
         expect(state).to.eql({
             ready: false,
-            diseases: emptyLookup<Disease>(),
+            diseases: emptyLoadable<Disease>(),
             modellingGroups: {
                 loaded: true,
                 content: {

--- a/app/src/test/contrib/stores/ResponsibilityStoreTests.ts
+++ b/app/src/test/contrib/stores/ResponsibilityStoreTests.ts
@@ -17,7 +17,7 @@ import { responsibilityStore } from "../../../main/contrib/stores/Responsibility
 import { coverageSetActions } from "../../../main/contrib/actions/CoverageSetActions";
 import { coverageTokenActions } from "../../../main/contrib/actions/CoverageActions";
 import { modellingGroupActions } from "../../../main/shared/actions/ModellingGroupActions";
-import { makeLookup } from "../../../main/contrib/stores/Loadable";
+import { makeLoadable } from "../../../main/contrib/stores/Loadable";
 import { ModellingGroup } from "../../../main/shared/models/Generated";
 
 describe("ResponsibilityStore", () => {
@@ -47,7 +47,7 @@ describe("ResponsibilityStore", () => {
     it("modellingGroupActions.setCurrentModellingGroup sets current modelling group", () => {
         const group = mockModellingGroup();
         alt.bootstrap(JSON.stringify({
-            MainStore: { modellingGroups: makeLookup<ModellingGroup>([ group ]) }
+            MainStore: { modellingGroups: makeLoadable<ModellingGroup>([ group ]) }
         }));
         modellingGroupActions.setCurrentGroup(group.id);
         expect(responsibilityStore.getState().currentModellingGroup).to.eql(group);
@@ -114,7 +114,7 @@ describe("ResponsibilityStore", () => {
         const touchstoneB = mockTouchstone();
         alt.bootstrap(JSON.stringify({
             MainStore: {
-                modellingGroups: makeLookup([ groupA, groupB ])
+                modellingGroups: makeLoadable([ groupA, groupB ])
             },
             ResponsibilityStore: {
                 touchstones: [ touchstoneA, touchstoneB ],
@@ -191,7 +191,7 @@ describe("ResponsibilityStore", () => {
         const responsibility = mockExtendedResponsibility({}, scenario);
         const responsibilities = [ responsibility, mockResponsibility() ];
         alt.bootstrap(JSON.stringify({
-            MainStore: { modellingGroups: makeLookup([group]) },
+            MainStore: { modellingGroups: makeLoadable([group]) },
             ResponsibilityStore: {
                 touchstones: [ touchstone ],
                 currentModellingGroup: group,

--- a/app/src/test/mocks/mocks.ts
+++ b/app/src/test/mocks/mocks.ts
@@ -1,7 +1,7 @@
 import { Location } from "simple-react-router";
 import * as models from "../../main/shared/models/Generated";
 import { alt } from "../../main/shared/alt";
-import { makeLookup } from "../../main/contrib/stores/Loadable";
+import { makeLoadable } from "../../main/contrib/stores/Loadable";
 import { ILookup } from "../../main/shared/models/Lookup";
 
 export function mockLocation<T>(params?: T): Location<T> {
@@ -20,8 +20,8 @@ export function setupMainStore(config: {
 {
     alt.bootstrap(JSON.stringify({
         MainStore: {
-            diseases: makeLookup<models.Disease>(config.diseases),
-            modellingGroups: makeLookup<models.ModellingGroup>(config.groups),
+            diseases: makeLoadable<models.Disease>(config.diseases),
+            modellingGroups: makeLoadable<models.ModellingGroup>(config.groups),
         }
     }));
 }


### PR DESCRIPTION
We have ILookup (which is just a dictionary, or plain JavaScript object).

And then we have `ILoadable`, which is a lookup + a boolean to track whether it has been loaded yet.

Alll the helper functions for `ILoadable` have `ILookup` in the name (e.g. `getFromLookup`), and there is no helper method that just works with a plain `ILookup`.

This PR fixes those problems.