### PR TITLE
replace slashes with colons

### DIFF
--- a/app/src/main/report/components/Artefacts/Artefact.tsx
+++ b/app/src/main/report/components/Artefacts/Artefact.tsx
@@ -13,7 +13,8 @@ interface ArtefactProps
 export class ArtefactItem extends React.Component<ArtefactProps, undefined> {
     render() {
         const p = this.props;
-        const url = `/reports/${p.report}/${p.version}/artefacts/${p.filename}/`;
+        const filename = p.filename.replace("/", ":");
+        const url = `/reports/${p.report}/${p.version}/artefacts/${filename}/`;
         return <li>
             <FileDownloadLink key={this.props.filename} href={url}>
                 {p.filename}

--- a/app/src/main/report/components/Artefacts/Artefact.tsx
+++ b/app/src/main/report/components/Artefacts/Artefact.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import {settings} from "../../../shared/Settings";
 import { FileDownloadLink } from "../FileDownloadLink";
+import { encodeFilename } from "../../../shared/Helpers";
 
 interface ArtefactProps
 {
@@ -13,7 +14,7 @@ interface ArtefactProps
 export class ArtefactItem extends React.Component<ArtefactProps, undefined> {
     render() {
         const p = this.props;
-        const filename = p.filename.replace("/", ":");
+        const filename = encodeFilename(p.filename);
         const url = `/reports/${p.report}/${p.version}/artefacts/${filename}/`;
         return <li>
             <FileDownloadLink key={this.props.filename} href={url}>

--- a/app/src/main/report/components/Resources/ResourceLinks.tsx
+++ b/app/src/main/report/components/Resources/ResourceLinks.tsx
@@ -11,6 +11,7 @@ interface ResourceLinksProps{
 
 export class ResourceLinks extends React.Component<ResourceLinksProps, undefined> {
     buildUrl(resource: string): string {
+        resource = resource.replace("/", ":");
         const p = this.props;
         return `/reports/${p.report}/${p.version}/resources/${resource}/`;
     }

--- a/app/src/main/report/components/Resources/ResourceLinks.tsx
+++ b/app/src/main/report/components/Resources/ResourceLinks.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import {ILookup} from "../../../shared/models/Lookup";
 import {settings} from "../../../shared/Settings";
 import { FileDownloadLink } from "../FileDownloadLink";
+import { encodeFilename } from "../../../shared/Helpers";
 
 interface ResourceLinksProps{
     resources: string[],
@@ -11,7 +12,7 @@ interface ResourceLinksProps{
 
 export class ResourceLinks extends React.Component<ResourceLinksProps, undefined> {
     buildUrl(resource: string): string {
-        resource = resource.replace("/", ":");
+        resource = encodeFilename(resource);
         const p = this.props;
         return `/reports/${p.report}/${p.version}/resources/${resource}/`;
     }

--- a/app/src/main/report/components/Resources/ResourceLinks.tsx
+++ b/app/src/main/report/components/Resources/ResourceLinks.tsx
@@ -13,7 +13,7 @@ export class ResourceLinks extends React.Component<ResourceLinksProps, undefined
     buildUrl(resource: string): string {
         resource = resource.replace("/", ":");
         const p = this.props;
-        return `/reports/${p.report}/${p.version}/resources/${encodeURIComponent(resource)}/`;
+        return `/reports/${p.report}/${p.version}/resources/${resource}/`;
     }
 
     render() {

--- a/app/src/main/shared/Helpers.ts
+++ b/app/src/main/shared/Helpers.ts
@@ -1,3 +1,7 @@
 export function doNothing() {
 
 }
+
+export function encodeFilename(filename: String) {
+    return filename.replace("/", ":");
+}

--- a/app/src/test/report/components/Artefacts/ArtefactItemTests.tsx
+++ b/app/src/test/report/components/Artefacts/ArtefactItemTests.tsx
@@ -11,13 +11,13 @@ describe("ArtefactItem", () => {
 
     it("renders link", () => {
 
-        const rendered = sandbox.mount(<ArtefactItem report="reportname" version="versionname" filename="filename.csv" description="a file" />);
+        const rendered = sandbox.mount(<ArtefactItem report="reportname" version="versionname" filename="subdir/filename.csv" description="a file" />);
         const item = rendered.find("li").at(0);
         const link = item.find(FileDownloadLink);
 
         expect(rendered.find("li").length).to.eq(1);
-        expect(link.prop("href")).to.eq("/reports/reportname/versionname/artefacts/filename.csv/");
-        expect(link.text()).to.eq("filename.csv");
+        expect(link.prop("href")).to.eq("/reports/reportname/versionname/artefacts/subdir:filename.csv/");
+        expect(link.text()).to.eq("subdir/filename.csv");
 
     });
 

--- a/app/src/test/report/components/Resources/ResourceLinksTest.tsx
+++ b/app/src/test/report/components/Resources/ResourceLinksTest.tsx
@@ -13,14 +13,14 @@ describe("ResourceLinks", () => {
     it("can render", () => {
 
         const testResources = {
-            "someresource.csv": "23774uhkjhjk",
+            "R/someresource.csv": "23774uhkjhjk",
             "someother.rds": "480ujkdnsckjkl;"
         };
 
         const rendered = sandbox.mount(<ResourceLinks resources={testResources} report="reportname" version="versionname" />);
         const links = rendered.find('li').find(FileDownloadLink);
 
-        expect(links.at(0).prop("href")).to.eq("/reports/reportname/versionname/resources/someresource.csv/");
+        expect(links.at(0).prop("href")).to.eq("/reports/reportname/versionname/resources/R:someresource.csv/");
         expect(links.at(1).prop("href")).to.eq("/reports/reportname/versionname/resources/someother.rds/");
     });
 


### PR DESCRIPTION
update resource and artefact links to use the new encoding for route params - colons in place of slashes