### PR TITLE
Disable user create form while request is pending

### DIFF
--- a/app/src/main/admin/components/Users/Create/CreateUserForm.tsx
+++ b/app/src/main/admin/components/Users/Create/CreateUserForm.tsx
@@ -22,32 +22,34 @@ export class CreateUserFormComponent extends React.Component<ReformProps, undefi
     render() {
         const fields = this.props.fields as CreateUserFields;
         return <form className={commonStyles.gapAbove} onSubmit={this.props.submit}>
-            <div className={commonStyles.sectionTitle}>Add new user</div>
-            <table className={formStyles.tableForm}>
-                <tbody>
-                <tr>
-                    <td>Full name</td>
-                    <td><input name="name" type="string" {...fields.name} onChange={this.changeName} /></td>
-                    <td><ValidationError message={this.props.errors.name}/></td>
-                </tr>
-                <tr>
-                    <td>Email address</td>
-                    <td><input name="email" type="email" {...fields.email} /></td>
-                    <td><ValidationError message={this.props.errors.email}/></td>
-                </tr>
-                <tr>
-                    <td>Username</td>
-                    <td><input name="username" type="string" {...fields.username} /></td>
-                    <td><ValidationError message={this.props.errors.username}/></td>
-                </tr>
-                </tbody>
-            </table>
-            <div className={commonStyles.gapAbove}>
-                <ValidationError message={this.props.store.state.submitError}/>
-            </div>
-            <div className={commonStyles.gapAbove}>
-                <button type="submit">Save user</button>
-            </div>
+            <fieldset disabled={this.props.loading}>
+                <div className={commonStyles.sectionTitle}>Add new user</div>
+                <table className={formStyles.tableForm}>
+                    <tbody>
+                    <tr>
+                        <td>Full name</td>
+                        <td><input name="name" {...fields.name} onChange={this.changeName} /></td>
+                        <td><ValidationError message={this.props.errors.name}/></td>
+                    </tr>
+                    <tr>
+                        <td>Email address</td>
+                        <td><input name="email" type="email" {...fields.email} /></td>
+                        <td><ValidationError message={this.props.errors.email}/></td>
+                    </tr>
+                    <tr>
+                        <td>Username</td>
+                        <td><input name="username" {...fields.username} /></td>
+                        <td><ValidationError message={this.props.errors.username}/></td>
+                    </tr>
+                    </tbody>
+                </table>
+                <div className={commonStyles.gapAbove}>
+                    <ValidationError message={this.props.store.state.submitError}/>
+                </div>
+                <div className={commonStyles.gapAbove}>
+                    <button type="submit">Save user</button>
+                </div>
+            </fieldset>
         </form>;
     }
 }

--- a/app/src/main/admin/components/Users/Create/CreateUserFormStore.ts
+++ b/app/src/main/admin/components/Users/Create/CreateUserFormStore.ts
@@ -3,7 +3,7 @@ import { alt } from "../../../../shared/alt";
 import FormActions from "../../../../shared/FormActions";
 import * as Validation from "../../../../shared/Validation";
 import fetcher from "../../../../shared/sources/Fetcher";
-import { NotificationException } from "../../../../shared/actions/NotificationActions";
+import { notificationActions, NotificationException } from "../../../../shared/actions/NotificationActions";
 import { userStore } from "../../../stores/UserStore";
 import { processResponseAndNotifyOnErrors } from "../../../../shared/sources/Source";
 import { FormErrors, justState } from "../../../../shared/FormHelpers";
@@ -35,7 +35,7 @@ export function createUserFormStore(name?: string): Reform<CreateUserFields> {
                 .then(() => userStore.fetchUsers(true))
                 .catch(e => {
                     const n = e as NotificationException;
-                    alt.dispatch(submitFailed(n.notification.message));
+                    notificationActions.notify(n.notification);
                 });
         },
         onSubmitFail: (response: any) => {

--- a/app/src/main/shared/styles/common.css
+++ b/app/src/main/shared/styles/common.css
@@ -22,6 +22,13 @@ table tr th, :local(.specialColumn) td:first-child {
     vertical-align: top;
 }
 
+fieldset {
+    display: inline;
+    border: none;
+    margin: 0;
+    padding: 0;
+}
+
 :local(.largeSectionTitle) {
     font-family: header;
     font-size: 24pt;


### PR DESCRIPTION
https://vimc.myjetbrains.com/youtrack/issue/VIMC-585

There's also another small change here: I switched to using notificationActions for errors in the form. This is maybe not ideal UI-wise, but it matches your work on the set password form, and it means that if a redirect occurs (for example if the user's token has expired) they still see the message.

We should have a proper chat at some point about unifying feedback from forms.