### PR TITLE
Turn off caching.

### DIFF
--- a/app/docker/nginx.default.conf
+++ b/app/docker/nginx.default.conf
@@ -13,7 +13,7 @@ server {
     # CSS and JS files (do cache these)
     location ~* \.(?:css|js)$ {
       try_files $uri =404;
-      expires 1y;
+      expires -1;
       access_log off;
       add_header Cache-Control "public";
     }


### PR DESCRIPTION
https://vimc.myjetbrains.com/youtrack/issue/VIMC-578

This doesn't actually disable caching; it just ensures that clients check with the server what the latest version is before deciding whether to use their local cached copy or the newer one.