### PR TITLE
Rename components

### DIFF
--- a/app/src/integrationTests/ReportIntegrationTests.tsx
+++ b/app/src/integrationTests/ReportIntegrationTests.tsx
@@ -13,7 +13,7 @@ import { Sandbox } from "../test/Sandbox";
 import { ArtefactItem } from "../main/report/components/Artefacts/ArtefactItem";
 import { FileDownloadLink } from "../main/report/components/FileDownloadLink";
 import { ResourceLinks } from "../main/report/components/Resources/ResourceLinks";
-import { VersionDetailsComponent } from "../main/report/components/Versions/VersionDetails";
+import { ReportDetailsComponent } from "../main/report/components/Reports/ReportDetails";
 import { DataLinks } from "../main/report/components/Data/DataLinks";
 
 const jwt_decode = require('jwt-decode');
@@ -148,7 +148,7 @@ class ReportIntegrationTests extends IntegrationTestSuite {
             const promise = getVersionDetails(reportName)
                 .then((versionDetails: Version) => {
 
-                    const rendered = shallow(<VersionDetailsComponent
+                    const rendered = shallow(<ReportDetailsComponent
                         ready={true}
                         report={reportName}
                         versionDetails={versionDetails}

--- a/app/src/main/report/components/ReportingRouter.tsx
+++ b/app/src/main/report/components/ReportingRouter.tsx
@@ -5,7 +5,7 @@ import {appSettings} from "../../shared/Settings";
 import {MainMenu} from "./MainMenu/MainMenu";
 import {ReportingNoRouteFoundPage} from "./ReportingNoRouteFoundPage";
 import {ReportingLoginPage} from "./ReportingLoginPage";
-import {VersionInfoPage} from "./Versions/VersionInfoPage";
+import {ReportPage} from "./Reports/ReportPage";
 import {ReportingForgottenPasswordPage} from "./ReportingForgottenPasswordPage";
 
 interface RouterProps {
@@ -22,7 +22,7 @@ export class ReportingRouter extends Router<RouterProps> {
 
         if (props.loggedIn) {
             map('/', MainMenu);
-            map('/:report/:version/', VersionInfoPage);
+            map('/:report/:version/', ReportPage);
             map('*', ReportingNoRouteFoundPage);
         } else {
             map('*', ReportingLoginPage);

--- a/app/src/main/report/components/Reports/ReportDetails.tsx
+++ b/app/src/main/report/components/Reports/ReportDetails.tsx
@@ -24,7 +24,7 @@ export interface VersionProps extends RemoteContent, PublicProps {
     allVersions: string[];
 }
 
-export class VersionDetailsComponent extends RemoteContentComponent<VersionProps> {
+export class ReportDetailsComponent extends RemoteContentComponent<VersionProps> {
     static getStores() {
         return [reportStore];
     }
@@ -91,4 +91,4 @@ export class VersionDetailsComponent extends RemoteContentComponent<VersionProps
     }
 }
 
-export const VersionDetails = connectToStores(VersionDetailsComponent) as ComponentConstructor<PublicProps, undefined>;
+export const ReportDetails = connectToStores(ReportDetailsComponent) as ComponentConstructor<PublicProps, undefined>;

--- a/app/src/main/report/components/Reports/ReportDetails.tsx
+++ b/app/src/main/report/components/Reports/ReportDetails.tsx
@@ -18,18 +18,18 @@ interface PublicProps {
     onChangeVersion: (version: string) => void;
 }
 
-export interface VersionProps extends RemoteContent, PublicProps {
+export interface ReportDetailsProps extends RemoteContent, PublicProps {
     versionDetails: Version;
     report: string;
     allVersions: string[];
 }
 
-export class ReportDetailsComponent extends RemoteContentComponent<VersionProps> {
+export class ReportDetailsComponent extends RemoteContentComponent<ReportDetailsProps> {
     static getStores() {
         return [reportStore];
     }
 
-    static getPropsFromStores(props: Partial<VersionProps>): VersionProps {
+    static getPropsFromStores(props: Partial<ReportDetailsProps>): ReportDetailsProps {
         const s = reportStore.getState();
         return {
             versionDetails: s.versionDetails[s.currentVersion],
@@ -43,7 +43,7 @@ export class ReportDetailsComponent extends RemoteContentComponent<VersionProps>
         };
     }
 
-    private renderTable(props: VersionProps) {
+    private renderTable(props: ReportDetailsProps) {
         const url = `/reports/${props.report}/versions/${props.versionDetails.id}/all/`;
         const version = props.versionDetails.id;
 
@@ -79,7 +79,7 @@ export class ReportDetailsComponent extends RemoteContentComponent<VersionProps>
         </table>;
     }
 
-    renderContent(props: VersionProps) {
+    renderContent(props: ReportDetailsProps) {
         return <div>
             <ReportVersionSwitcher
                 currentVersion={props.versionDetails.id}

--- a/app/src/main/report/components/Reports/ReportPage.tsx
+++ b/app/src/main/report/components/Reports/ReportPage.tsx
@@ -1,19 +1,19 @@
 import * as React from "react";
 import {reportActions} from "../../actions/ReportActions";
 import {ReportingPageWithHeader} from "../ReportingPageWithHeader";
-import {VersionDetails} from "./VersionDetails";
+import {ReportDetails} from "./ReportDetails";
 import {reportStore} from "../../stores/ReportStore";
 import {doNothing} from "../../../shared/Helpers";
 import {PageProperties} from "../../../shared/components/PageWithHeader/PageWithHeader";
 import {appSettings} from "../../../shared/Settings";
 
-export interface VersionInfoPageProps {
+export interface ReportPageProps {
     report: string;
     version: string;
 }
 
-export class VersionInfoPage extends ReportingPageWithHeader<VersionInfoPageProps> {
-    constructor(props: PageProperties<VersionInfoPageProps>) {
+export class ReportPage extends ReportingPageWithHeader<ReportPageProps> {
+    constructor(props: PageProperties<ReportPageProps>) {
         super(props);
         this.changeVersion = this.changeVersion.bind(this);
     }
@@ -44,6 +44,6 @@ export class VersionInfoPage extends ReportingPageWithHeader<VersionInfoPageProp
     }
 
     renderPageContent() {
-        return <VersionDetails onChangeVersion={this.changeVersion} />;
+        return <ReportDetails onChangeVersion={this.changeVersion} />;
     }
 }

--- a/app/src/main/report/components/Reports/ReportVersionSwitcher.tsx
+++ b/app/src/main/report/components/Reports/ReportVersionSwitcher.tsx
@@ -1,8 +1,6 @@
 import * as React from "react";
 import {VersionIdentifier} from "../../models/VersionIdentifier";
 import {longTimestamp} from "../../../shared/Helpers";
-import {IRouter, Router} from "simple-react-router";
-import {VersionInfoPage} from "./VersionInfoPage";
 
 const styles = require("../../styles/reports.css");
 

--- a/app/src/test/report/components/Reports/ReportDetailsTests.tsx
+++ b/app/src/test/report/components/Reports/ReportDetailsTests.tsx
@@ -2,15 +2,14 @@ import * as React from "react";
 import {shallow} from "enzyme";
 import {expect} from "chai";
 import {alt} from "../../../../main/shared/alt";
-import {VersionDetailsComponent, VersionProps} from "../../../../main/report/components/Versions/VersionDetails";
+import {ReportDetailsComponent, VersionProps} from "./ReportDetails";
 import {mockVersion} from "../../../mocks/mockModels";
 import {FileDownloadLink} from "../../../../main/report/components/FileDownloadLink";
-import {mockRouter} from "../../../mocks/mockRouter";
 import {Sandbox} from "../../../Sandbox";
-import {ReportVersionSwitcher} from "../../../../main/report/components/Versions/ReportVersionSwitcher";
+import {ReportVersionSwitcher} from "./ReportVersionSwitcher";
 import {ReportStoreState} from "../../../../main/report/stores/ReportStore";
 
-describe("VersionDetails", () => {
+describe("ReportDetails", () => {
     const sandbox = new Sandbox();
     afterEach(() => sandbox.restore());
 
@@ -34,7 +33,7 @@ describe("VersionDetails", () => {
         };
 
         const assertIsNotReady = function() {
-            expect(VersionDetailsComponent.getPropsFromStores({}).ready).to.equal(false);
+            expect(ReportDetailsComponent.getPropsFromStores({}).ready).to.equal(false);
         };
 
         it("is ready when state is correct", () => {
@@ -49,7 +48,7 @@ describe("VersionDetails", () => {
                 allVersions: ["v1", "v2", "v3"],
                 onChangeVersion: onChangeVersion
             };
-            expect(VersionDetailsComponent.getPropsFromStores(inputProps)).to.eql(expected);
+            expect(ReportDetailsComponent.getPropsFromStores(inputProps)).to.eql(expected);
         });
 
         it("is not ready if store is not ready", () => {
@@ -69,7 +68,7 @@ describe("VersionDetails", () => {
     });
 
     it("renders date", () => {
-        const rendered = shallow(<VersionDetailsComponent
+        const rendered = shallow(<ReportDetailsComponent
             versionDetails={mockVersion({date: "2015-03-25"})}
             report="reportname"
             allVersions={[]}
@@ -80,7 +79,7 @@ describe("VersionDetails", () => {
     });
 
     it("renders zip download link", () => {
-        const rendered = shallow(<VersionDetailsComponent
+        const rendered = shallow(<ReportDetailsComponent
             versionDetails={mockVersion({id: "v1"})}
             report="reportname"
             allVersions={[]}
@@ -92,7 +91,7 @@ describe("VersionDetails", () => {
 
     it("renders report version switcher", () => {
         const handler = sandbox.sinon.stub();
-        const rendered = shallow(<VersionDetailsComponent
+        const rendered = shallow(<ReportDetailsComponent
             versionDetails={mockVersion({id: "v1"})}
             report="reportname"
             allVersions={["v1", "v2"]}
@@ -108,7 +107,7 @@ describe("VersionDetails", () => {
 
     it("emits onChangeVersion when switcher triggers it", () => {
         const handler = sandbox.sinon.stub();
-        const rendered = shallow(<VersionDetailsComponent
+        const rendered = shallow(<ReportDetailsComponent
             versionDetails={mockVersion({id: "v1"})}
             report="reportname"
             allVersions={["v1", "v2"]}

--- a/app/src/test/report/components/Reports/ReportDetailsTests.tsx
+++ b/app/src/test/report/components/Reports/ReportDetailsTests.tsx
@@ -2,12 +2,12 @@ import * as React from "react";
 import {shallow} from "enzyme";
 import {expect} from "chai";
 import {alt} from "../../../../main/shared/alt";
-import {ReportDetailsComponent, VersionProps} from "./ReportDetails";
 import {mockVersion} from "../../../mocks/mockModels";
 import {FileDownloadLink} from "../../../../main/report/components/FileDownloadLink";
 import {Sandbox} from "../../../Sandbox";
-import {ReportVersionSwitcher} from "./ReportVersionSwitcher";
 import {ReportStoreState} from "../../../../main/report/stores/ReportStore";
+import {ReportDetailsComponent, ReportDetailsProps} from "../../../../main/report/components/Reports/ReportDetails";
+import {ReportVersionSwitcher} from "../../../../main/report/components/Reports/ReportVersionSwitcher";
 
 describe("ReportDetails", () => {
     const sandbox = new Sandbox();
@@ -41,7 +41,7 @@ describe("ReportDetails", () => {
             const onChangeVersion = sandbox.sinon.stub();
             const inputProps = {onChangeVersion};
 
-            const expected: VersionProps = {
+            const expected: ReportDetailsProps = {
                 report: "reportname",
                 versionDetails: mockVersion(),
                 ready: true,

--- a/app/src/test/report/components/Reports/ReportListComponentTests.tsx
+++ b/app/src/test/report/components/Reports/ReportListComponentTests.tsx
@@ -2,11 +2,11 @@ import * as React from "react";
 import { expect } from "chai";
 import { shallow } from "enzyme";
 
-import {ReportListComponent} from "../../../main/report/components/Reports/ReportList";
-import {ReportListItem} from "../../../main/report/components/Reports/ReportListItem";
-import {alt} from "../../../main/shared/alt";
-import { mockResponse } from "../../mocks/mockRemote";
-import { mockReport } from "../../mocks/mockModels";
+import {ReportListComponent} from "./ReportList";
+import {ReportListItem} from "./ReportListItem";
+import {alt} from "../../../../main/shared/alt";
+import { mockResponse } from "../../../mocks/mockRemote";
+import { mockReport } from "../../../mocks/mockModels";
 
 describe("ReportListComponent", () => {
     it("can get props from stores", () => {

--- a/app/src/test/report/components/Reports/ReportListComponentTests.tsx
+++ b/app/src/test/report/components/Reports/ReportListComponentTests.tsx
@@ -1,12 +1,10 @@
 import * as React from "react";
 import { expect } from "chai";
 import { shallow } from "enzyme";
-
-import {ReportListComponent} from "./ReportList";
-import {ReportListItem} from "./ReportListItem";
 import {alt} from "../../../../main/shared/alt";
-import { mockResponse } from "../../../mocks/mockRemote";
 import { mockReport } from "../../../mocks/mockModels";
+import {ReportListComponent} from "../../../../main/report/components/Reports/ReportList";
+import {ReportListItem} from "../../../../main/report/components/Reports/ReportListItem";
 
 describe("ReportListComponent", () => {
     it("can get props from stores", () => {

--- a/app/src/test/report/components/Reports/ReportListItemTests.tsx
+++ b/app/src/test/report/components/Reports/ReportListItemTests.tsx
@@ -1,9 +1,9 @@
 import * as React from "react";
 import {expect} from "chai";
 import {shallow} from "enzyme";
-import {ReportListItem} from "../../../main/report/components/Reports/ReportListItem";
-import {Report} from "../../../main/shared/models/Generated";
-import {InternalLink} from "../../../main/shared/components/InternalLink";
+import {ReportListItem} from "./ReportListItem";
+import {Report} from "../../../../main/shared/models/Generated";
+import {InternalLink} from "../../../../main/shared/components/InternalLink";
 
 interface LinkProps {
     url: string;

--- a/app/src/test/report/components/Reports/ReportListItemTests.tsx
+++ b/app/src/test/report/components/Reports/ReportListItemTests.tsx
@@ -1,9 +1,9 @@
 import * as React from "react";
 import {expect} from "chai";
 import {shallow} from "enzyme";
-import {ReportListItem} from "./ReportListItem";
 import {Report} from "../../../../main/shared/models/Generated";
 import {InternalLink} from "../../../../main/shared/components/InternalLink";
+import {ReportListItem} from "../../../../main/report/components/Reports/ReportListItem";
 
 interface LinkProps {
     url: string;

--- a/app/src/test/report/components/Reports/ReportPageTests.tsx
+++ b/app/src/test/report/components/Reports/ReportPageTests.tsx
@@ -6,10 +6,10 @@ import {mockLocation} from "../../../mocks/mocks";
 import {checkAsync} from "../../../testHelpers";
 import {reportStore} from "../../../../main/report/stores/ReportStore";
 import {expectOneAction} from "../../../actionHelpers";
-import {ReportPage, ReportPageProps} from "./ReportPage";
 import {alt} from "../../../../main/shared/alt";
 import {IRouter} from "simple-react-router";
-import {ReportDetails} from "./ReportDetails";
+import {ReportPage, ReportPageProps} from "../../../../main/report/components/Reports/ReportPage";
+import {ReportDetails} from "../../../../main/report/components/Reports/ReportDetails";
 
 describe("ReportPage", () => {
     const sandbox = new Sandbox();

--- a/app/src/test/report/components/Reports/ReportPageTests.tsx
+++ b/app/src/test/report/components/Reports/ReportPageTests.tsx
@@ -6,12 +6,12 @@ import {mockLocation} from "../../../mocks/mocks";
 import {checkAsync} from "../../../testHelpers";
 import {reportStore} from "../../../../main/report/stores/ReportStore";
 import {expectOneAction} from "../../../actionHelpers";
-import {VersionInfoPage, VersionInfoPageProps} from "../../../../main/report/components/Versions/VersionInfoPage";
+import {ReportPage, ReportPageProps} from "./ReportPage";
 import {alt} from "../../../../main/shared/alt";
 import {IRouter} from "simple-react-router";
-import {VersionDetails} from "../../../../main/report/components/Versions/VersionDetails";
+import {ReportDetails} from "./ReportDetails";
 
-describe("VersionInfoPage", () => {
+describe("ReportPage", () => {
     const sandbox = new Sandbox();
 
     afterEach(() => sandbox.restore());
@@ -47,8 +47,8 @@ describe("VersionInfoPage", () => {
 
     it("triggers actions on mount", (done: DoneCallback) => {
         checkExpectedActionsWhen(done, () => {
-            const location = mockLocation<VersionInfoPageProps>({report: "reportname", version: "versionname"});
-            new VersionInfoPage({location: location, router: null}).componentDidMount();
+            const location = mockLocation<ReportPageProps>({report: "reportname", version: "versionname"});
+            new ReportPage({location: location, router: null}).componentDidMount();
         });
     });
 
@@ -57,9 +57,9 @@ describe("VersionInfoPage", () => {
         const router: IRouter = {redirectTo};
 
         checkExpectedActionsWhen(done, () => {
-            const location = mockLocation<VersionInfoPageProps>({report: "reportname", version: "oldVersion"});
-            const rendered = shallow(<VersionInfoPage location={location} router={router} />);
-            rendered.find(VersionDetails).simulate("changeVersion", "versionname");
+            const location = mockLocation<ReportPageProps>({report: "reportname", version: "oldVersion"});
+            const rendered = shallow(<ReportPage location={location} router={router} />);
+            rendered.find(ReportDetails).simulate("changeVersion", "versionname");
             expect(redirectTo.called).to.equal(true, "Expected redirectTo to be called");
             expect(redirectTo.calledWith("/reportname/versionname/"));
         });

--- a/app/src/test/report/components/Reports/ReportVersionSwitcherTests.tsx
+++ b/app/src/test/report/components/Reports/ReportVersionSwitcherTests.tsx
@@ -1,8 +1,8 @@
 import {shallow} from "enzyme";
 import {expect} from "chai";
 import * as React from "react";
-import {ReportVersionSwitcher} from "./ReportVersionSwitcher";
 import {Sandbox} from "../../../Sandbox";
+import {ReportVersionSwitcher} from "../../../../main/report/components/Reports/ReportVersionSwitcher";
 
 describe("ReportVersionSwitcher", () => {
     const sandbox = new Sandbox();

--- a/app/src/test/report/components/Reports/ReportVersionSwitcherTests.tsx
+++ b/app/src/test/report/components/Reports/ReportVersionSwitcherTests.tsx
@@ -1,7 +1,7 @@
 import {shallow} from "enzyme";
 import {expect} from "chai";
 import * as React from "react";
-import {ReportVersionSwitcher} from "../../../../main/report/components/Versions/ReportVersionSwitcher";
+import {ReportVersionSwitcher} from "./ReportVersionSwitcher";
 import {Sandbox} from "../../../Sandbox";
 
 describe("ReportVersionSwitcher", () => {


### PR DESCRIPTION
This is a refactor preliminary to the rest of the [VIMC-868](https://vimc.myjetbrains.com/youtrack/issue/VIMC-868) to rename the `VersionInfoPage` to `ReportPage`. I know that this page is still displaying one version of the report at a time, but given it is now the only page that displays anything about a report, I thought this simpler naming scheme was better.