### PR TITLE
extra test and fixed functionality

### DIFF
--- a/app/src/main/shared/sources/Source.ts
+++ b/app/src/main/shared/sources/Source.ts
@@ -50,6 +50,10 @@ export function processResponseAndNotifyOnErrors<TModel>(response: Response): Pr
 
 export function processEncodedResultAndNotifyOnErrors<TModel>(queryAsObject: any): TModel | void {
 
+    if (!queryAsObject.result){
+        return
+    }
+
     try {
         const decoded = jwtDecoder.jwtDecode(queryAsObject.result);
         const result = JSON.parse(decoded.result);

--- a/app/src/test/shared/fetch/SourceTests.ts
+++ b/app/src/test/shared/fetch/SourceTests.ts
@@ -4,7 +4,7 @@ import {Sandbox} from "../../Sandbox";
 import {jwtDecoder} from "../../../main/shared/sources/JwtDecoder";
 import {mockResult} from "../../mocks/mockRemote";
 import {makeNotificationException} from "../../../main/shared/actions/NotificationActions";
-import {expectOneAction} from "../../actionHelpers";
+import {expectNoActions, expectOneAction} from "../../actionHelpers";
 
 describe("processEncodedResultAndNotifyOnErrors", () => {
 
@@ -39,6 +39,15 @@ describe("processEncodedResultAndNotifyOnErrors", () => {
             action: "NotificationActions.notify",
             payload: { type: "error", message: "an error" }
         });
+    });
+
+    it("does nothing if result does not exist", () => {
+        const spy = sandbox.dispatchSpy();
+
+        const obj = {} as any;
+        processEncodedResultAndNotifyOnErrors<string>(obj);
+
+        expectNoActions(spy);
     });
 
 });


### PR DESCRIPTION
Bug - if the query string on the upload estimate page is empty, jwt_decode throws an error