### PR TITLE
fix for bug with dots in route

### DIFF
--- a/app/src/main/admin/components/Users/List/UserListItem.tsx
+++ b/app/src/main/admin/components/Users/List/UserListItem.tsx
@@ -1,10 +1,11 @@
 import * as React from "react";
 import { InternalLink } from "../../../../shared/components/InternalLink";
 import {User} from "../../../../shared/models/Generated";
+import {helpers} from "../../../../shared/Helpers";
 
 export class UserListItem extends React.Component<User, undefined> {
     render() {
-        const url = `/users/${ this.props.username }/`;
+        const url = `/users/${ helpers.dotsToHyphens(this.props.username) }/`;
         return <tr>
                     <td><InternalLink href={ url }>{ this.props.username}
                         </InternalLink>

--- a/app/src/main/admin/components/Users/SingleUser/ViewUserDetailsPage.tsx
+++ b/app/src/main/admin/components/Users/SingleUser/ViewUserDetailsPage.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { connectToStores } from "../../../../shared/alt";
 import { AdminPageWithHeader } from "../../AdminPageWithHeader";
-import { doNothing } from "../../../../shared/Helpers";
+import {doNothing, helpers} from "../../../../shared/Helpers";
 import {UserTitle, UserTitleProps} from "./UserTitle";
 import {UserDetailsContent} from "./UserDetailsContent";
 import {userActions} from "../../../actions/UserActions";
@@ -16,7 +16,7 @@ export interface UserDetailsPageProps {
 export class ViewUserDetailsPage extends AdminPageWithHeader<UserDetailsPageProps> {
     load() {
         userStore.fetchUsers().catch(doNothing).then(() => {
-            userActions.setCurrentUser(this.props.location.params.username);
+            userActions.setCurrentUser(helpers.hyphensToDots(this.props.location.params.username));
             super.load();
         });
     }

--- a/app/src/main/shared/Helpers.ts
+++ b/app/src/main/shared/Helpers.ts
@@ -35,5 +35,13 @@ export const helpers = {
             obj[key] = value;
         });
         return obj;
+    },
+
+    dotsToHyphens(name: string): string {
+        return name && name.replace(/\./g, "-")
+    },
+
+    hyphensToDots(name: string): string {
+        return name && name.replace(/-/g, ".")
     }
 };

--- a/app/src/test/admin/components/Users/List/UserListItemTests.tsx
+++ b/app/src/test/admin/components/Users/List/UserListItemTests.tsx
@@ -4,6 +4,7 @@ import { expect } from "chai";
 import {UserListItem} from "../../../../../main/admin/components/Users/List/UserListItem";
 import {mockUser} from "../../../../mocks/mockModels";
 import {User} from "../../../../../main/shared/models/Generated";
+import {InternalLink} from "../../../../../main/shared/components/InternalLink";
 
 describe("UserListItem", () => {
     it("can render", () => {
@@ -20,5 +21,17 @@ describe("UserListItem", () => {
         const lastLoggedIn = cells.at(3).text();
         expect(lastLoggedIn).to.eq("never")
     });
+
+    it("makes link", () => {
+
+        const user: User = mockUser();
+        user.last_logged_in = null;
+        user.username = "some.user";
+        const rendered = shallow(<UserListItem { ...user } />);
+        const link = rendered.find(InternalLink);
+
+        const href = link.prop("href");
+        expect(href).to.eq("/users/some-user/")
+    })
 
 });

--- a/app/src/test/admin/components/Users/SingleUser/ViewUserDetailsPageTests.tsx
+++ b/app/src/test/admin/components/Users/SingleUser/ViewUserDetailsPageTests.tsx
@@ -13,21 +13,20 @@ import { alt } from "../../../../../main/shared/alt";
 import { mockUser } from "../../../../mocks/mockModels";
 import {addNavigationTests} from "../../../../shared/NavigationTests";
 import {mockFetcherForMultipleResponses} from "../../../../mocks/mockMultipleEndpoints";
-import {successResult} from "../../../../mocks/mockRemote";
 import {mockUsersEndpoint} from "../../../../mocks/mockEndpoints";
 
 describe("ViewUserDetailsPage", () => {
     const sandbox = new Sandbox();
     afterEach(() => sandbox.restore());
 
-    const location = mockLocation<UserDetailsPageProps>({ username: "testuser" });
+    const location = mockLocation<UserDetailsPageProps>({ username: "test.user" });
 
     it("triggers fetch on load", (done: DoneCallback) => {
         alt.bootstrap(JSON.stringify({
             UserStore: {
-                currentUsername: "testuser",
+                currentUsername: "test.user",
                 usersLookup: {
-                    "testuser": mockUser(),
+                    "test.user": mockUser(),
                 },
                 rolesLookup: {
                 }
@@ -42,7 +41,7 @@ describe("ViewUserDetailsPage", () => {
         checkAsync(done, (afterWait) => {
             expect(fetchUsers.called).to.equal(true, "Expected userStore.fetchUsers to be triggered");
             afterWait(done, () => {
-                expectOneAction(dispatchSpy, { action: "UserActions.setCurrentUser", payload: "testuser" });
+                expectOneAction(dispatchSpy, { action: "UserActions.setCurrentUser", payload: "test.user" });
              });
         });
     });

--- a/app/src/test/shared/helpers/FormattingTests.ts
+++ b/app/src/test/shared/helpers/FormattingTests.ts
@@ -1,0 +1,24 @@
+import {expect} from "chai";
+import {helpers} from "../../../main/shared/Helpers";
+
+describe("String formatting helpers", () => {
+
+    it("can turn dots to hyphens", () => {
+        expect(helpers.dotsToHyphens("some.name")).to.equal("some-name");
+        expect(helpers.dotsToHyphens("some.thing.with.lots.of.dots")).to.equal("some-thing-with-lots-of-dots");
+        expect(helpers.dotsToHyphens("many..hyphens")).to.equal("many--hyphens");
+        expect(helpers.dotsToHyphens(null)).to.equal(null);
+        expect(helpers.dotsToHyphens("blah")).to.equal("blah");
+    });
+
+
+    it("can turn hyphens to dots", () => {
+        expect(helpers.hyphensToDots("some-name")).to.equal("some.name");
+        expect(helpers.hyphensToDots("some-thing-with-lots-of-dots")).to.equal("some.thing.with.lots.of.dots");
+        expect(helpers.hyphensToDots("many--hyphens")).to.equal("many..hyphens");
+        expect(helpers.hyphensToDots(null)).to.equal(null);
+        expect(helpers.hyphensToDots("blah")).to.equal("blah");
+    });
+
+
+});


### PR DESCRIPTION
nginx doesn't like dots in the route (read it like a file extension.) I think the best solution is just to avoid dots in routes. Means the url won't exactly match the username but I think that's ok. I went with hypens instead, but we could also just do without the dots...