### PR TITLE
remove unused props

### DIFF
--- a/app/src/main/contrib/components/Responsibilities/BurdenEstimates/UploadBurdenEstimatesContent.tsx
+++ b/app/src/main/contrib/components/Responsibilities/BurdenEstimates/UploadBurdenEstimatesContent.tsx
@@ -1,11 +1,11 @@
 import * as React from "react";
-import { connectToStores } from "../../../../shared/alt";
-import { ModellingGroup, Responsibility, Scenario, Touchstone } from "../../../../shared/models/Generated";
-import { RemoteContent } from "../../../../shared/models/RemoteContent";
-import { RemoteContentComponent } from "../../../../shared/components/RemoteContentComponent/RemoteContentComponent";
-import { responsibilityStore } from "../../../stores/ResponsibilityStore";
-import { UploadForm } from "./UploadForm";
-import { TemplateLink } from "../Overview/List/TemplateLinks";
+import {connectToStores} from "../../../../shared/alt";
+import {ModellingGroup, Responsibility, Scenario, Touchstone} from "../../../../shared/models/Generated";
+import {RemoteContent} from "../../../../shared/models/RemoteContent";
+import {RemoteContentComponent} from "../../../../shared/components/RemoteContentComponent/RemoteContentComponent";
+import {responsibilityStore} from "../../../stores/ResponsibilityStore";
+import {UploadForm} from "./UploadForm";
+import {TemplateLink} from "../Overview/List/TemplateLinks";
 
 const commonStyles = require("../../../../shared/styles/common.css");
 
@@ -78,11 +78,10 @@ export class UploadBurdenEstimatesContentComponent extends RemoteContentComponen
             </table>
 
             <div className={commonStyles.gapAbove}>
-                <UploadForm groupId={data.group.id}
-                            token={data.estimatesToken}
+                <UploadForm token={data.estimatesToken}
                             canUpload={canUploadBurdenEstimate}
                             currentEstimateSet={data.responsibility.current_estimate_set}
-                            scenarioId={data.scenario.id}/>
+                />
             </div>
         </div>;
     }

--- a/app/src/main/contrib/components/Responsibilities/BurdenEstimates/UploadForm.tsx
+++ b/app/src/main/contrib/components/Responsibilities/BurdenEstimates/UploadForm.tsx
@@ -9,9 +9,7 @@ const buttonStyles = require("../../../../shared/styles/buttons.css");
 const styles = require("../Responsibilities.css");
 
 export interface UploadFormProps {
-    groupId: string;
     canUpload: boolean;
-    scenarioId: string;
     currentEstimateSet: BurdenEstimateSet;
     token: string;
 }

--- a/app/src/test/contrib/components/Responsibilities/Uploads/UploadEstimatesContentTests.tsx
+++ b/app/src/test/contrib/components/Responsibilities/Uploads/UploadEstimatesContentTests.tsx
@@ -36,8 +36,6 @@ describe("UploadEstimatesContentComponent", () => {
         expect(rendered.find(UploadForm).props()).to.eql({
             token: "TOKEN",
             canUpload: true,
-            groupId: "group-1",
-            scenarioId: "scenario-id",
             currentEstimateSet: null
         });
     });

--- a/app/src/test/contrib/components/Responsibilities/Uploads/UploadFormTests.tsx
+++ b/app/src/test/contrib/components/Responsibilities/Uploads/UploadFormTests.tsx
@@ -1,64 +1,50 @@
 import * as React from "react";
-import { expect } from "chai";
-import { UploadForm } from "../../../../../main/contrib/components/Responsibilities/BurdenEstimates/UploadForm";
-import { shallow, ShallowWrapper } from "enzyme";
-import {mockBurdenEstimateSet, mockResponsibility, mockScenario} from "../../../../mocks/mockModels";
-import { setupMainStore } from "../../../../mocks/mocks";
-import { BurdenEstimateSet } from "../../../../../main/shared/models/Generated";
-import { Sandbox } from "../../../../Sandbox";
+import {expect} from "chai";
+import {UploadForm} from "../../../../../main/contrib/components/Responsibilities/BurdenEstimates/UploadForm";
+import {shallow, ShallowWrapper} from "enzyme";
+import {mockBurdenEstimateSet, mockResponsibility} from "../../../../mocks/mockModels";
+import {Sandbox} from "../../../../Sandbox";
 import {mockFetcher} from "../../../../mocks/mockRemote";
 import {CurrentEstimateSetSummary} from "../../../../../main/contrib/components/Responsibilities/Overview/List/CurrentEstimateSetSummary";
 
 const buttonStyles = require("../../../../../main/shared/styles/buttons.css");
-const messageStyles = require("../../../../../main/shared/styles/messages.css");
 
 describe('UploadForm', () => {
     let rendered: ShallowWrapper<any, any>;
     const sandbox = new Sandbox();
     before(() => mockFetcher(Promise.resolve(null)));
 
-    function setUpComponent(canUpload: boolean,
-                            burdenEstimateSet?: BurdenEstimateSet,
-                            token: string = "TOKEN") {
-        setupMainStore({
-            diseases: [
-                { id: "disease-id", name: "Disease name" }
-            ]
-        });
-
-        const responsibility = mockResponsibility({
-            status: "empty",
-            current_estimate_set: burdenEstimateSet
-        }, mockScenario({
-            id: "scenario-1",
-            description: "Description",
-        }));
-
-        rendered = shallow(<UploadForm
-            token={token}
-            canUpload={canUpload}
-            groupId={"group-1"}
-            scenarioId={responsibility.scenario.id}
-            currentEstimateSet={responsibility.current_estimate_set}/>);
-    }
-
     afterEach(() => sandbox.restore());
 
     it("disables the choose file button if canUpload is false", () => {
-        setUpComponent(false);
+
+        rendered = shallow(<UploadForm
+            token={"token"}
+            canUpload={false}
+            currentEstimateSet={null}/>);
+
         const chooseFileButton = rendered.find(`.${buttonStyles.button}`).first();
         expect(chooseFileButton.text()).to.eq("No more burden estimates can be uploaded");
         expect(chooseFileButton.hasClass(buttonStyles.disabled)).to.eq(true);
     });
 
     it("disables the choose file button if token is null", () => {
-        setUpComponent(true, null, null);
+
+        rendered = shallow(<UploadForm
+            token={null}
+            canUpload={true}
+            currentEstimateSet={null}/>);
+
         const uploadButton = rendered.find(`button`).first();
         expect(uploadButton.prop("disabled")).to.eq(true);
     });
 
     it("enables choose file button if canUpload is true", () => {
-        setUpComponent(true);
+
+        rendered = shallow(<UploadForm
+            token={"token"}
+            canUpload={true}
+            currentEstimateSet={null}/>);
 
         const chooseFileButton = rendered.find(`.${buttonStyles.button}`).first();
         expect(chooseFileButton.text()).to.eq("Choose a new burden estimate set");
@@ -66,8 +52,17 @@ describe('UploadForm', () => {
     });
 
     it("renders current burden estimate status", () => {
+
         const set = mockBurdenEstimateSet();
-        setUpComponent(true, set);
+        const responsibility = mockResponsibility(
+            {
+                current_estimate_set: set
+            });
+
+        rendered = shallow(<UploadForm
+            token={"token"}
+            canUpload={true}
+            currentEstimateSet={responsibility.current_estimate_set}/>);
 
         const element = rendered.find(CurrentEstimateSetSummary);
         expect(element).to.have.length(1);


### PR DESCRIPTION
Noticed that `UploadForm` no longer uses `groupId` or `scenarioId` so have removed these from its props.