### PR TITLE
I1006 - Should have the page entity name in the breadcrumb.

### DIFF
--- a/app/src/main/admin/components/ModellingGroups/SingleGroup/Details/ViewModellingGroupDetailsPage.tsx
+++ b/app/src/main/admin/components/ModellingGroups/SingleGroup/Details/ViewModellingGroupDetailsPage.tsx
@@ -26,7 +26,8 @@ export class ViewModellingGroupDetailsPage extends AdminPageWithHeader<Modelling
     }
 
     name(): string {
-        return "Group details";
+        const s = groupStore.getState();
+        return s.currentGroupId;
     }
 
     urlFragment(): string {

--- a/app/src/main/admin/components/Users/SingleUser/ViewUserDetailsPage.tsx
+++ b/app/src/main/admin/components/Users/SingleUser/ViewUserDetailsPage.tsx
@@ -22,7 +22,8 @@ export class ViewUserDetailsPage extends AdminPageWithHeader<UserDetailsPageProp
     }
 
     name(): string {
-        return "User details";
+        const s = userStore.getState();
+        return s.currentUsername;
     }
 
     title(): JSX.Element {

--- a/app/src/main/contrib/components/ChooseAction/ChooseActionPage.tsx
+++ b/app/src/main/contrib/components/ChooseAction/ChooseActionPage.tsx
@@ -20,7 +20,8 @@ export class ChooseActionPage extends ContribPageWithHeader<LocationProps> {
     }
 
     name(): string {
-        return "Touchstones";
+        const s = responsibilityStore.getState();
+        return s.currentModellingGroup.id;
     }
 
     title(): JSX.Element {

--- a/app/src/main/contrib/components/ChooseAction/ChooseActionPage.tsx
+++ b/app/src/main/contrib/components/ChooseAction/ChooseActionPage.tsx
@@ -21,7 +21,7 @@ export class ChooseActionPage extends ContribPageWithHeader<LocationProps> {
 
     name(): string {
         const s = responsibilityStore.getState();
-        return s.currentModellingGroup.id;
+        return s.currentModellingGroup.description;
     }
 
     title(): JSX.Element {

--- a/app/src/main/contrib/components/Responsibilities/BurdenEstimates/UploadBurdenEstimatesPage.tsx
+++ b/app/src/main/contrib/components/Responsibilities/BurdenEstimates/UploadBurdenEstimatesPage.tsx
@@ -45,7 +45,7 @@ export class UploadBurdenEstimatesPage extends ContribPageWithHeader<UploadEstim
 
     name() {
         const r = responsibilityStore.getState();
-        return r.currentResponsibility.scenario.id;
+        return `Upload burden estimates for ${r.currentResponsibility.scenario.description}`;
     }
 
     title() {

--- a/app/src/main/contrib/components/Responsibilities/BurdenEstimates/UploadBurdenEstimatesPage.tsx
+++ b/app/src/main/contrib/components/Responsibilities/BurdenEstimates/UploadBurdenEstimatesPage.tsx
@@ -44,7 +44,8 @@ export class UploadBurdenEstimatesPage extends ContribPageWithHeader<UploadEstim
     }
 
     name() {
-        return "Upload burden estimates";
+        const r = responsibilityStore.getState();
+        return r.currentResponsibility.scenario.id;
     }
 
     title() {

--- a/app/src/main/contrib/components/Responsibilities/Coverage/DownloadCoveragePage.tsx
+++ b/app/src/main/contrib/components/Responsibilities/Coverage/DownloadCoveragePage.tsx
@@ -32,7 +32,7 @@ export class DownloadCoveragePage extends ContribPageWithHeader<LocationProps> {
 
     name() {
         const s = responsibilityStore.getState();
-        return s.currentResponsibility.scenario.id;
+        return `Download coverage for ${s.currentResponsibility.scenario.description}`;
     }
 
     title() {

--- a/app/src/main/contrib/components/Responsibilities/Coverage/DownloadCoveragePage.tsx
+++ b/app/src/main/contrib/components/Responsibilities/Coverage/DownloadCoveragePage.tsx
@@ -31,7 +31,8 @@ export class DownloadCoveragePage extends ContribPageWithHeader<LocationProps> {
     }
 
     name() {
-        return "Download coverage data";
+        const s = responsibilityStore.getState();
+        return s.currentResponsibility.scenario.id;
     }
 
     title() {

--- a/app/src/main/contrib/components/Responsibilities/Overview/ResponsibilityOverviewPage.tsx
+++ b/app/src/main/contrib/components/Responsibilities/Overview/ResponsibilityOverviewPage.tsx
@@ -28,7 +28,8 @@ export class ResponsibilityOverviewPage extends ContribPageWithHeader<LocationPr
     }
 
     name() {
-        return "Responsibilities";
+        const s = responsibilityStore.getState();
+        return s.currentTouchstone.id;
     }
 
     title() {

--- a/app/src/main/contrib/components/Responsibilities/Overview/ResponsibilityOverviewPage.tsx
+++ b/app/src/main/contrib/components/Responsibilities/Overview/ResponsibilityOverviewPage.tsx
@@ -29,7 +29,7 @@ export class ResponsibilityOverviewPage extends ContribPageWithHeader<LocationPr
 
     name() {
         const s = responsibilityStore.getState();
-        return s.currentTouchstone.id;
+        return s.currentTouchstone.description;
     }
 
     title() {

--- a/app/src/main/shared/components/NavBar/NavBar.css
+++ b/app/src/main/shared/components/NavBar/NavBar.css
@@ -1,13 +1,14 @@
 :local(.navbar) {
     background-color: rgb(200, 200, 200);
-    padding: 5px 10px;
+    padding: 2px 5px 5px 7px;
     color: black;
 }
 
 :local(.chunk) {
     font-weight: bold;
+    font-size: 13px;
     display: inline-block;
-    margin: 0 10px;
+    margin: 0 5px 0 0;
 }
 
 :local(.chunk):before {


### PR DESCRIPTION
Should have the page entity name in the breadcrumb.

for example:

in Contrib: 
Url: 
/IC-Garske/responsibilities/op-2017-2/coverage/yf-routine/
Breadcrumb:
Modellers' contribution portal> IC-Garske > op-2017-2 > yf-routine

In Admin:
Url: 
/users/test.user/
Breadcrumb:
Main menu > Users > test.user

