### PR TITLE
move actions inside load method

### DIFF
--- a/app/src/main/contrib/components/Responsibilities/BurdenEstimates/UploadBurdenEstimatesPage.tsx
+++ b/app/src/main/contrib/components/Responsibilities/BurdenEstimates/UploadBurdenEstimatesPage.tsx
@@ -19,10 +19,13 @@ export interface UploadEstimatesProps {
 }
 
 export class UploadBurdenEstimatesPage extends ContribPageWithHeader<UploadEstimatesProps> {
+
     load(props: UploadEstimatesProps) {
-        estimateTokenActions.clearUsedToken();
-        estimateTokenActions.setRedirectPath(this.props.location.pathname);
+
         return this.loadParent(props).then(() => {
+            estimateTokenActions.clearUsedToken();
+            estimateTokenActions.setRedirectPath(this.props.location.pathname);
+
             responsibilityActions.setCurrentResponsibility(props.scenarioId);
             responsibilityStore.fetchOneTimeEstimatesToken().catch(doNothing);
         });

--- a/app/src/main/contrib/components/Responsibilities/ModelRunParameters/ModelRunParametersContent.tsx
+++ b/app/src/main/contrib/components/Responsibilities/ModelRunParameters/ModelRunParametersContent.tsx
@@ -24,7 +24,7 @@ export class ModelRunParametersContentComponent
         const state = responsibilityStore.getState();
 
         return {
-            ready: state.ready,
+            ready: state.ready && state.currentTouchstone != null,
             touchstone: state.currentTouchstone,
             group: state.currentModellingGroup,
             diseases: Array.from(new Set([].concat.apply([],


### PR DESCRIPTION
The `UploadBurdenEstimatesPage` does not load on page refresh, or when navigating to the url directly (as opposed to through the canonical link path.) This means that when users upload estimates and the page refreshes, they see an infinite loading spinner.

When navigating directly to the `ModelRunParametersPage`, there is also an error. The `ModelRunParametersContentComponent` should wait for the current touchstone to be non null before declaring itself `ready`.