### PR TITLE
update integration tests

### DIFF
--- a/app/src/integrationTests/ContribIntegrationTests.tsx
+++ b/app/src/integrationTests/ContribIntegrationTests.tsx
@@ -337,7 +337,6 @@ class ContributionPortalIntegrationTests extends IntegrationTestSuite {
                 expectIsEqual<ModelRunParameterSet[]>(parameterSets, [
                     {
                         id: 1,
-                        description: 'description',
                         model: "model-1",
                         disease: "yf",
                         uploaded_on: '2017-12-25T12:00:00Z',

--- a/app/src/integrationTests/ContribIntegrationTests.tsx
+++ b/app/src/integrationTests/ContribIntegrationTests.tsx
@@ -76,7 +76,6 @@ class ContributionPortalIntegrationTests extends IntegrationTestSuite {
                 return addModel(this.db).then(() => {
 
                     form.append('disease', 'yf');
-                    form.append('description', 'something');
 
                     return fetcher.fetcher.fetch(url, {
                         method: "POST",
@@ -575,7 +574,7 @@ function addModelRunParameterSets(db: Client): Promise<QueryResult> {
                         RETURNING id INTO upload_info_id;
             
                     INSERT INTO model_run_parameter_set 
-                    (responsibility_set, description, model_version, upload_info)
+                    (responsibility_set, model_version, upload_info)
                     VALUES 
                     (${ids.responsibilitySet}, 'description', ${ids.modelVersion}, upload_info_id);
                 END $$;

--- a/app/src/integrationTests/ContribIntegrationTests.tsx
+++ b/app/src/integrationTests/ContribIntegrationTests.tsx
@@ -576,7 +576,7 @@ function addModelRunParameterSets(db: Client): Promise<QueryResult> {
                     INSERT INTO model_run_parameter_set 
                     (responsibility_set, model_version, upload_info)
                     VALUES 
-                    (${ids.responsibilitySet}, 'description', ${ids.modelVersion}, upload_info_id);
+                    (${ids.responsibilitySet}, ${ids.modelVersion}, upload_info_id);
                 END $$;
             `);
         });

--- a/app/src/main/contrib/components/Responsibilities/ModelRunParameters/ModelRunParametersForm.tsx
+++ b/app/src/main/contrib/components/Responsibilities/ModelRunParameters/ModelRunParametersForm.tsx
@@ -40,7 +40,6 @@ export class ModelRunParametersForm extends React.Component<Props, State> {
                   successMessage={"Success! You have uploaded a new parameter set"}
                   successCallback={this.onSuccess.bind(this)}
                   data={null}>
-                <input type={"hidden"} name={"description"} value={""}/>
                 <input type={"hidden"} name={"disease"} value={this.props.disease}/>
                 <CustomFileInput required={true} key={this.state.fileInputKey.toISOString()}>Choose
                     file</CustomFileInput>

--- a/app/src/main/shared/models/Generated.ts
+++ b/app/src/main/shared/models/Generated.ts
@@ -58,7 +58,6 @@ export interface ModellingGroupDetails {
 }
 
 export interface ModelRunParameterSet {
-    description: string;
     disease: string;
     id: number;
     model: string;
@@ -72,7 +71,7 @@ export interface Report {
     name: string;
 }
 
-export type BurdenEstimateSetStatus = "empty" | "complete";
+export type BurdenEstimateSetStatus = "empty" | "partial" | "complete";
 
 export type BurdenEstimateSetTypeCode = "central-single-run" | "central-averaged" | "central-unknown" | "stochastic";
 
@@ -83,6 +82,7 @@ export interface BurdenEstimateSetType {
 
 export interface BurdenEstimateSet {
     id: number;
+    is_stochastic: boolean;
     problems: string[];
     status: BurdenEstimateSetStatus;
     type: BurdenEstimateSetType;

--- a/app/src/main/shared/models/Generated.ts
+++ b/app/src/main/shared/models/Generated.ts
@@ -82,7 +82,6 @@ export interface BurdenEstimateSetType {
 
 export interface BurdenEstimateSet {
     id: number;
-    is_stochastic: boolean;
     problems: string[];
     status: BurdenEstimateSetStatus;
     type: BurdenEstimateSetType;

--- a/app/src/test/contrib/components/Responsibilities/ModelRunParameters/ModelRunParametersFormTests.tsx
+++ b/app/src/test/contrib/components/Responsibilities/ModelRunParameters/ModelRunParametersFormTests.tsx
@@ -38,15 +38,4 @@ describe('ModelRunParameterForm', () => {
 
     });
 
-    it("populate hidden description input", () => {
-
-        rendered = shallow(<ModelRunParametersForm
-            url={"url"}
-            disease={"d1"}
-        />);
-
-        const input = rendered.find('input[name="description"][type="hidden"]');
-        expect(input).to.have.lengthOf(1);
-    });
-
 });

--- a/app/src/test/mocks/mockModels.ts
+++ b/app/src/test/mocks/mockModels.ts
@@ -209,7 +209,6 @@ export function mockModelRunParameterSet(properties?: Partial<models.ModelRunPar
     counter++;
     const template: models.ModelRunParameterSet = {
         id: counter,
-        description: "description",
         disease: "Yellow Fever",
         model: "model-1",
         uploaded_on: "2017-07-13 13:45:29 +0100",


### PR DESCRIPTION
Some integration tests were trying to populate the dropped 'description' column on the model run parameters table.

Also removed the empty description field from the upload form