### PR TITLE
sort by date by default

### DIFF
--- a/app/src/main/report/components/ReportsList/ReportListColumns/VersionColumn.tsx
+++ b/app/src/main/report/components/ReportsList/ReportListColumns/VersionColumn.tsx
@@ -6,9 +6,9 @@ import {VersionFilterValue} from "./LatestVersionFilter";
 
 export const LatestVersionCell: React.StatelessComponent<ReportRowRenderProps> = (props: ReportRowRenderProps) => {
     const value = props.value as LatestVersion;
-    return <div className="small">
-        <div>{value.version}</div>
-        <div>({longDate(value.date)})</div>
+    return <div>
+        <div>{longDate(value.date)}</div>
+        <div className="small">({value.version})</div>
     </div>
 };
 
@@ -23,6 +23,13 @@ export const versionFilterMethod = (filter: FilterGeneric<VersionFilterValue>, r
     return lastUpdatedDate <= filter.value.end
         && lastUpdatedDate >= filter.value.start &&
         lastVersionId.toLowerCase().indexOf(filter.value.versionId.toLowerCase()) > -1;
+};
+
+export const versionSortMethod = (a: LatestVersion, b: LatestVersion) => {
+    if (a.date > b.date){
+        return -1
+    }
+    return 1
 };
 
 export interface LatestVersion {

--- a/app/src/main/report/components/ReportsList/ReportListTable.tsx
+++ b/app/src/main/report/components/ReportsList/ReportListTable.tsx
@@ -5,7 +5,8 @@ import {
     LatestVersion,
     latestVersionAccessorFunction,
     LatestVersionCell,
-    versionFilterMethod
+    versionFilterMethod,
+    versionSortMethod
 } from "./ReportListColumns/VersionColumn";
 import {
     PublishStatusCell,
@@ -73,6 +74,7 @@ export const ReportsListTable: React.StatelessComponent<ReportsListTableProps>
                 width: 345,
                 accessor: latestVersionAccessorFunction,
                 Cell: LatestVersionCell,
+                sortMethod: versionSortMethod,
                 filterMethod: versionFilterMethod,
                 Filter: ReportLatestVersionFilter
             },
@@ -107,9 +109,10 @@ export const ReportsListTable: React.StatelessComponent<ReportsListTableProps>
             Find a report
         </h1>
         <p className="helper-text text-muted">
-            Click on a column heading to sort by that field. Hold shift to mulit-sort.
+            Click on a column heading to sort by that field. Hold shift to multi-sort.
         </p>
         <ReactTable
+            defaultSorted={[{id: "latest_version"}]}
             defaultFilterMethod={(filter: Filter, row: ReportRowProps) =>
                 String(row[filter.id]).toLowerCase().indexOf(filter.value.toLowerCase()) > -1}
             filterable

--- a/app/src/test/report/components/ReportsList/ReportListTable/LatestVersionColumnTests.tsx
+++ b/app/src/test/report/components/ReportsList/ReportListTable/LatestVersionColumnTests.tsx
@@ -7,7 +7,7 @@ import {Sandbox} from "../../../../Sandbox";
 import {
     latestVersionAccessorFunction,
     LatestVersionCell,
-    versionFilterMethod,
+    versionFilterMethod, versionSortMethod,
 } from "../../../../../main/report/components/ReportsList/ReportListColumns/VersionColumn";
 import {ReportLatestVersionFilter} from "../../../../../main/report/components/ReportsList/ReportListColumns/LatestVersionFilter";
 import {DateRangePicker} from "../../../../../main/shared/components/DatePicker/DateRangePicker";
@@ -42,8 +42,8 @@ describe("ReportListComponent", () => {
                                                           date: new Date(2018, 4, 15)
                                                       }}/>);
 
-            expect(result.find(".small").childAt(0).text()).to.eq("46324");
-            expect(result.find(".small").childAt(1).text()).to.eq("(Tue May 15 2018)");
+            expect(result.find("div").first().childAt(0).text()).to.eq("Tue May 15 2018");
+            expect(result.find("div").first().childAt(1).text()).to.eq("(46324)");
         });
 
         const filterValue = {
@@ -189,6 +189,16 @@ describe("ReportListComponent", () => {
 
             const result = versionFilterMethod(filter, row as any);
             expect(result).to.be.false;
+        });
+
+
+        it("sorts by date descending", function () {
+
+            const a = {date: new Date(2018, 5, 14), version: "1234"};
+            const b = {date: new Date(2018, 5, 13), version: "1234"};
+
+            const result = versionSortMethod(a, b);
+            expect(result).to.eq(-1);
         });
 
 


### PR DESCRIPTION
Add a custom sorter for the date so that the default sorting is descending, not ascending. Make the table sorted by date on page load. Flip the id and the date in the latest version cell.