### PR TITLE
Preliminary refactor

### DIFF
--- a/app/src/integrationTests/ContribIntegrationTests.tsx
+++ b/app/src/integrationTests/ContribIntegrationTests.tsx
@@ -18,7 +18,7 @@ import {createContribStore} from "../main/contrib/createStore";
 import { ModellingGroupsService } from "../main/shared/services/ModellingGroupsService";
 import {RunParametersService} from "../main/contrib/services/RunParametersService";
 import {DiseasesService} from "../main/contrib/services/DiseasesService";
-import {TouchstonesService} from "../main/contrib/services/TouchstonesService";
+import {TouchstonesService} from "../main/shared/services/TouchstonesService";
 import {ResponsibilitiesService} from "../main/contrib/services/ResponsibilitiesService";
 import {CoverageService} from "../main/contrib/services/CoverageService";
 import {DemographicService} from "../main/contrib/services/DemographicService";

--- a/app/src/main/contrib/actions/contribTouchstonesActionCreators.ts
+++ b/app/src/main/contrib/actions/contribTouchstonesActionCreators.ts
@@ -1,20 +1,20 @@
 import {Dispatch} from "redux";
 
 import {ContribAppState} from "../reducers/contribAppReducers";
-import {TouchstonesService} from "../services/TouchstonesService";
-import {SetCurrentTouchstoneVersion, TouchstonesFetched, TouchstoneTypes} from "../actionTypes/TouchstonesTypes";
+import {TouchstonesService} from "../../shared/services/TouchstonesService";
+import {SetCurrentTouchstoneVersion, TouchstonesFetchedForGroup, TouchstoneTypes} from "../../shared/actionTypes/TouchstonesTypes";
 import {Touchstone} from "../../shared/models/Generated";
 import {flatMap} from "../../shared/ArrayHelpers";
 
-export const touchstonesActionCreators = {
+export const contribTouchstonesActionCreators = {
 
     getTouchstonesByGroupId(groupId: string) {
         return async (dispatch: Dispatch<ContribAppState>, getState: () => ContribAppState) => {
             const touchstones: Touchstone[] = await (new TouchstonesService(dispatch, getState)).getTouchstonesByGroupId(groupId);
             return dispatch({
-                type: TouchstoneTypes.TOUCHSTONES_FETCHED,
+                type: TouchstoneTypes.TOUCHSTONES_FETCHED_FOR_GROUP,
                 data: touchstones
-            } as TouchstonesFetched );
+            } as TouchstonesFetchedForGroup );
         }
     },
 

--- a/app/src/main/contrib/actions/pages/chooseActionPageActionCreators.ts
+++ b/app/src/main/contrib/actions/pages/chooseActionPageActionCreators.ts
@@ -3,7 +3,7 @@ import { Dispatch } from "redux";
 import { modellingGroupsActionCreators } from "../modellingGroupsActionCreators";
 import {breadcrumbsActionCreators} from "../../../shared/actions/breadcrumbsActionsCreators";
 import {ChooseActionPageComponent, ChooseActionPageLocationProps} from "../../components/ChooseAction/ChooseActionPage";
-import {touchstonesActionCreators} from "../touchstonesActionCreators";
+import {contribTouchstonesActionCreators} from "../contribTouchstonesActionCreators";
 import {chooseGroupPageActionCreators} from "./chooseGroupPageActionCreators";
 import {ContribAppState} from "../../reducers/contribAppReducers";
 
@@ -20,7 +20,7 @@ export const chooseActionPageActionCreators = {
         return async (dispatch: Dispatch<ContribAppState>) => {
             await dispatch(chooseGroupPageActionCreators.loadData());
             dispatch(modellingGroupsActionCreators.setCurrentGroup(props.groupId));
-            await dispatch(touchstonesActionCreators.getTouchstonesByGroupId(props.groupId));
+            await dispatch(contribTouchstonesActionCreators.getTouchstonesByGroupId(props.groupId));
         }
     }
 

--- a/app/src/main/contrib/actions/pages/responsibilityOverviewPageActionCreators.ts
+++ b/app/src/main/contrib/actions/pages/responsibilityOverviewPageActionCreators.ts
@@ -1,7 +1,7 @@
 import { Dispatch } from "redux";
 
 import {breadcrumbsActionCreators} from "../../../shared/actions/breadcrumbsActionsCreators";
-import {touchstonesActionCreators} from "../touchstonesActionCreators";
+import {contribTouchstonesActionCreators} from "../contribTouchstonesActionCreators";
 import {ContribAppState} from "../../reducers/contribAppReducers";
 import {
     ResponsibilityOverviewPageComponent,
@@ -25,7 +25,7 @@ export const responsibilityOverviewPageActionCreators = {
         return async (dispatch: Dispatch<ContribAppState>) => {
             await dispatch(chooseActionPageActionCreators.loadData(props));
             await dispatch(diseasesActionCreators.getAllDiseases());
-            dispatch(touchstonesActionCreators.setCurrentTouchstoneVersion(props.touchstoneId));
+            dispatch(contribTouchstonesActionCreators.setCurrentTouchstoneVersion(props.touchstoneId));
             await dispatch(responsibilitiesActionCreators.getResponsibilitySet());
         }
     }

--- a/app/src/main/contrib/reducers/contribAppReducers.ts
+++ b/app/src/main/contrib/reducers/contribAppReducers.ts
@@ -4,7 +4,7 @@ import {routerReducer} from "react-router-redux";
 
 import { authReducer, AuthState } from "../../shared/reducers/authReducer";
 import { modellingGroupsReducer, ModellingGroupsState } from "./modellingGroupsReducer";
-import { touchstonesReducer, TouchstonesState } from "./touchstonesReducer";
+import { contribTouchstonesReducer, TouchstonesState } from "./contribTouchstonesReducer";
 import { diseasesReducer, DiseasesState } from "./diseasesReducer";
 import { responsibilitiesReducer, ResponsibilitiesState } from "./responsibilitiesReducer";
 import { demographicReducer, DemographicState } from "./demographicReducer";
@@ -36,7 +36,7 @@ const reducers = combineReducers({
     groups: modellingGroupsReducer,
     user: userReducer,
     breadcrumbs: breadcrumbsReducer,
-    touchstones: touchstonesReducer,
+    touchstones: contribTouchstonesReducer,
     responsibilities: responsibilitiesReducer,
     diseases: diseasesReducer,
     demographic: demographicReducer,

--- a/app/src/main/contrib/reducers/contribTouchstonesReducer.ts
+++ b/app/src/main/contrib/reducers/contribTouchstonesReducer.ts
@@ -1,5 +1,5 @@
-import {TouchstonesAction, TouchstoneTypes} from "../actionTypes/TouchstonesTypes";
 import {Touchstone, TouchstoneVersion} from "../../shared/models/Generated";
+import {TouchstonesAction, TouchstoneTypes} from "../../shared/actionTypes/TouchstonesTypes";
 
 export interface TouchstonesState {
     touchstones: Touchstone[];
@@ -11,9 +11,9 @@ export const touchstonesInitialState: TouchstonesState = {
     currentTouchstoneVersion: null
 };
 
-export const touchstonesReducer = (state = touchstonesInitialState, action: TouchstonesAction): TouchstonesState => {
+export const contribTouchstonesReducer = (state = touchstonesInitialState, action: TouchstonesAction): TouchstonesState => {
     switch (action.type) {
-        case TouchstoneTypes.TOUCHSTONES_FETCHED:
+        case TouchstoneTypes.TOUCHSTONES_FETCHED_FOR_GROUP:
             return {...state, touchstones: action.data ? action.data : [] };
         case TouchstoneTypes.SET_CURRENT_TOUCHSTONE_VERSION:
             return {...state, currentTouchstoneVersion: action.data };

--- a/app/src/main/shared/actionTypes/TouchstonesTypes.ts
+++ b/app/src/main/shared/actionTypes/TouchstonesTypes.ts
@@ -1,12 +1,12 @@
 import {Touchstone, TouchstoneVersion} from "../../shared/models/Generated";
 
 export enum TouchstoneTypes {
-    TOUCHSTONES_FETCHED = "TOUCHSTONES_FETCHED",
+    TOUCHSTONES_FETCHED_FOR_GROUP = "TOUCHSTONES_FETCHED_FOR_GROUP",
     SET_CURRENT_TOUCHSTONE_VERSION = "SET_CURRENT_TOUCHSTONE_VERSION"
 }
 
-export interface TouchstonesFetched {
-    type: TouchstoneTypes.TOUCHSTONES_FETCHED;
+export interface TouchstonesFetchedForGroup {
+    type: TouchstoneTypes.TOUCHSTONES_FETCHED_FOR_GROUP;
     data: Touchstone[];
 }
 
@@ -16,5 +16,5 @@ export interface SetCurrentTouchstoneVersion {
 }
 
 export type TouchstonesAction =
-    | TouchstonesFetched
+    | TouchstonesFetchedForGroup
     | SetCurrentTouchstoneVersion

--- a/app/src/main/shared/services/TouchstonesService.ts
+++ b/app/src/main/shared/services/TouchstonesService.ts
@@ -1,8 +1,7 @@
-import { AbstractLocalService } from "../../shared/services/AbstractLocalService";
+import {AbstractLocalService} from "../../shared/services/AbstractLocalService";
 import {Touchstone} from "../../shared/models/Generated";
 
 export class TouchstonesService extends AbstractLocalService {
-
     getTouchstonesByGroupId(groupId: string): Promise<Touchstone[]> {
         return this.setOptions({cacheKey: TouchstonesCacheKeysEnum.touchstones})
             .get(`/modelling-groups/${groupId}/responsibilities/`);

--- a/app/src/test/contrib/actions/ContribTouchstonesActionsTests.ts
+++ b/app/src/test/contrib/actions/ContribTouchstonesActionsTests.ts
@@ -1,14 +1,14 @@
 import {expect} from "chai";
 
 import {Sandbox} from "../../Sandbox";
-import {touchstonesActionCreators} from "../../../main/contrib/actions/touchstonesActionCreators";
-import {TouchstonesService} from "../../../main/contrib/services/TouchstonesService";
-import {TouchstoneTypes} from "../../../main/contrib/actionTypes/TouchstonesTypes";
+import {contribTouchstonesActionCreators} from "../../../main/contrib/actions/contribTouchstonesActionCreators";
+import {TouchstonesService} from "../../../main/shared/services/TouchstonesService";
+import {TouchstoneTypes} from "../../../main/shared/actionTypes/TouchstonesTypes";
 import {createMockContribStore} from "../../mocks/mockStore";
 import {mockTouchstone, mockTouchstoneVersion} from "../../mocks/mockModels";
-import {TouchstonesState} from "../../../main/contrib/reducers/touchstonesReducer";
+import {TouchstonesState} from "../../../main/contrib/reducers/contribTouchstonesReducer";
 
-describe("Touchstone actions tests", () => {
+describe("Contrib touchstone actions tests", () => {
     const sandbox = new Sandbox();
 
     const testTouchstone = mockTouchstone();
@@ -22,10 +22,10 @@ describe("Touchstone actions tests", () => {
         sandbox.setStubFunc(TouchstonesService.prototype, "getTouchstonesByGroupId", () => {
             return Promise.resolve([testTouchstone]);
         });
-        store.dispatch(touchstonesActionCreators.getTouchstonesByGroupId('group-1'));
+        store.dispatch(contribTouchstonesActionCreators.getTouchstonesByGroupId('group-1'));
         setTimeout(() => {
             const actions = store.getActions();
-            const expectedPayload = {type: TouchstoneTypes.TOUCHSTONES_FETCHED, data: [testTouchstone]};
+            const expectedPayload = {type: TouchstoneTypes.TOUCHSTONES_FETCHED_FOR_GROUP, data: [testTouchstone]};
             expect(actions).to.eql([expectedPayload]);
             done();
         });
@@ -37,7 +37,7 @@ describe("Touchstone actions tests", () => {
             touchstones: [mockTouchstone({}, [testTouchstoneVersion])]
         };
         const store = createMockContribStore({touchstones: touchstonesState});
-        store.dispatch(touchstonesActionCreators.setCurrentTouchstoneVersion("touchstone-1"));
+        store.dispatch(contribTouchstonesActionCreators.setCurrentTouchstoneVersion("touchstone-1"));
         setTimeout(() => {
             const actions = store.getActions();
             // console.log(actions);

--- a/app/src/test/contrib/actions/pages/ChooseActionPageActionsTests.ts
+++ b/app/src/test/contrib/actions/pages/ChooseActionPageActionsTests.ts
@@ -8,8 +8,8 @@ import {BreadcrumbsTypes} from "../../../../main/shared/actionTypes/BreadrumbsTy
 import {breadcrumbsModule} from "../../../../main/shared/modules/breadcrumbs";
 import {mockBreadcrumbs, mockModellingGroup, mockTouchstoneVersion} from "../../../mocks/mockModels";
 import {chooseActionPageActionCreators} from "../../../../main/contrib/actions/pages/chooseActionPageActionCreators";
-import {TouchstonesService} from "../../../../main/contrib/services/TouchstonesService";
-import {TouchstoneTypes} from "../../../../main/contrib/actionTypes/TouchstonesTypes";
+import {TouchstonesService} from "../../../../main/shared/services/TouchstonesService";
+import {TouchstoneTypes} from "../../../../main/shared/actionTypes/TouchstonesTypes";
 
 describe("Choose Action Page actions tests", () => {
     const sandbox = new Sandbox();
@@ -46,7 +46,7 @@ describe("Choose Action Page actions tests", () => {
             const expectedPayload = [
                 { type: ModellingGroupTypes.USER_GROUPS_FETCHED, data: [testGroup] },
                 { type: ModellingGroupTypes.SET_CURRENT_USER_GROUP, data: testGroup },
-                { type: TouchstoneTypes.TOUCHSTONES_FETCHED, data: [testTouchstone]},
+                { type: TouchstoneTypes.TOUCHSTONES_FETCHED_FOR_GROUP, data: [testTouchstone]},
                 { type: BreadcrumbsTypes.BREADCRUMBS_RECEIVED, data: testBreadcrumbs }
             ];
             expect(actions).to.eql(expectedPayload);

--- a/app/src/test/contrib/actions/pages/DownloadCoveragePageActionsTests.ts
+++ b/app/src/test/contrib/actions/pages/DownloadCoveragePageActionsTests.ts
@@ -14,8 +14,8 @@ import {
     mockResponsibilitySet,
     mockTouchstone
 } from "../../../mocks/mockModels";
-import {TouchstonesService} from "../../../../main/contrib/services/TouchstonesService";
-import {TouchstoneTypes} from "../../../../main/contrib/actionTypes/TouchstonesTypes";
+import {TouchstonesService} from "../../../../main/shared/services/TouchstonesService";
+import {TouchstoneTypes} from "../../../../main/shared/actionTypes/TouchstonesTypes";
 import {DiseasesService} from "../../../../main/contrib/services/DiseasesService";
 import {ResponsibilitiesService} from "../../../../main/contrib/services/ResponsibilitiesService";
 import {DiseasesTypes} from "../../../../main/contrib/actionTypes/DiseasesTypes";
@@ -25,7 +25,7 @@ import {downloadCoveragePageActionCreators} from "../../../../main/contrib/actio
 import {CoverageService} from "../../../../main/contrib/services/CoverageService";
 import {ScenarioAndCoverageSets} from "../../../../main/shared/models/Generated";
 import {CoverageTypes} from "../../../../main/contrib/actionTypes/CoverageTypes";
-import {TouchstonesState} from "../../../../main/contrib/reducers/touchstonesReducer";
+import {TouchstonesState} from "../../../../main/contrib/reducers/contribTouchstonesReducer";
 
 describe("Download Coverage Page actions tests", () => {
     const sandbox = new Sandbox();
@@ -100,7 +100,7 @@ describe("Download Coverage Page actions tests", () => {
             const expectedPayload = [
                 {type: ModellingGroupTypes.USER_GROUPS_FETCHED, data: [testGroup]},
                 {type: ModellingGroupTypes.SET_CURRENT_USER_GROUP, data: testGroup},
-                {type: TouchstoneTypes.TOUCHSTONES_FETCHED, data: [testTouchstone]},
+                {type: TouchstoneTypes.TOUCHSTONES_FETCHED_FOR_GROUP, data: [testTouchstone]},
                 {type: DiseasesTypes.DISEASES_FETCHED, data: [testDisease]},
                 {type: TouchstoneTypes.SET_CURRENT_TOUCHSTONE_VERSION, data: testTouchstoneVersion},
                 {type: ResponsibilitiesTypes.SET_RESPONSIBILITIES, data: testExtResponsibilitySet},

--- a/app/src/test/contrib/actions/pages/DownloadDemographicPageActionsTests.ts
+++ b/app/src/test/contrib/actions/pages/DownloadDemographicPageActionsTests.ts
@@ -10,8 +10,8 @@ import {
     mockBreadcrumbs, mockDemographicDataset, mockDisease, mockModellingGroup, mockResponsibilitySet, mockTouchstone,
     mockTouchstoneVersion
 } from "../../../mocks/mockModels";
-import {TouchstonesService} from "../../../../main/contrib/services/TouchstonesService";
-import {TouchstoneTypes} from "../../../../main/contrib/actionTypes/TouchstonesTypes";
+import {TouchstonesService} from "../../../../main/shared/services/TouchstonesService";
+import {TouchstoneTypes} from "../../../../main/shared/actionTypes/TouchstonesTypes";
 import {DiseasesService} from "../../../../main/contrib/services/DiseasesService";
 import {ResponsibilitiesService} from "../../../../main/contrib/services/ResponsibilitiesService";
 import {DiseasesTypes} from "../../../../main/contrib/actionTypes/DiseasesTypes";
@@ -20,7 +20,7 @@ import {ExtendedResponsibilitySet} from "../../../../main/contrib/models/Respons
 import {downloadDemographicsPageActionCreators} from "../../../../main/contrib/actions/pages/downloadDemographicsPageActionCreators";
 import {DemographicService} from "../../../../main/contrib/services/DemographicService";
 import {DemographicTypes} from "../../../../main/contrib/actionTypes/DemographicTypes";
-import {TouchstonesState} from "../../../../main/contrib/reducers/touchstonesReducer";
+import {TouchstonesState} from "../../../../main/contrib/reducers/contribTouchstonesReducer";
 
 describe("Download Demographic Page actions tests", () => {
     const sandbox = new Sandbox();
@@ -77,7 +77,7 @@ describe("Download Demographic Page actions tests", () => {
             const expectedPayload = [
                 { type: ModellingGroupTypes.USER_GROUPS_FETCHED, data: [testGroup] },
                 { type: ModellingGroupTypes.SET_CURRENT_USER_GROUP, data: testGroup },
-                { type: TouchstoneTypes.TOUCHSTONES_FETCHED, data: [testTouchstone]},
+                { type: TouchstoneTypes.TOUCHSTONES_FETCHED_FOR_GROUP, data: [testTouchstone]},
                 { type: DiseasesTypes.DISEASES_FETCHED, data: [testDisease]},
                 { type: TouchstoneTypes.SET_CURRENT_TOUCHSTONE_VERSION, data: testTouchstoneVersion},
                 { type: ResponsibilitiesTypes.SET_RESPONSIBILITIES, data: testExtResponsibilitySet},

--- a/app/src/test/contrib/actions/pages/ModelRunParametersPageActionsTests.ts
+++ b/app/src/test/contrib/actions/pages/ModelRunParametersPageActionsTests.ts
@@ -14,8 +14,8 @@ import {
     mockResponsibilitySet,
     mockTouchstone
 } from "../../../mocks/mockModels";
-import {TouchstonesService} from "../../../../main/contrib/services/TouchstonesService";
-import {TouchstoneTypes} from "../../../../main/contrib/actionTypes/TouchstonesTypes";
+import {TouchstonesService} from "../../../../main/shared/services/TouchstonesService";
+import {TouchstoneTypes} from "../../../../main/shared/actionTypes/TouchstonesTypes";
 import {DiseasesService} from "../../../../main/contrib/services/DiseasesService";
 import {ResponsibilitiesService} from "../../../../main/contrib/services/ResponsibilitiesService";
 import {DiseasesTypes} from "../../../../main/contrib/actionTypes/DiseasesTypes";
@@ -24,7 +24,7 @@ import {ExtendedResponsibilitySet} from "../../../../main/contrib/models/Respons
 import {modelRunParametersPageActionCreators} from "../../../../main/contrib/actions/pages/modelRunParametersPageActionCreators";
 import {RunParametersService} from "../../../../main/contrib/services/RunParametersService";
 import {RunParametersTypes} from "../../../../main/contrib/actionTypes/RunParametersTypes";
-import {TouchstonesState} from "../../../../main/contrib/reducers/touchstonesReducer";
+import {TouchstonesState} from "../../../../main/contrib/reducers/contribTouchstonesReducer";
 
 describe("Model Run Parameters Page actions tests", () => {
     const sandbox = new Sandbox();
@@ -81,7 +81,7 @@ describe("Model Run Parameters Page actions tests", () => {
             const expectedPayload = [
                 {type: ModellingGroupTypes.USER_GROUPS_FETCHED, data: [testGroup]},
                 {type: ModellingGroupTypes.SET_CURRENT_USER_GROUP, data: testGroup},
-                {type: TouchstoneTypes.TOUCHSTONES_FETCHED, data: [testTouchstone]},
+                {type: TouchstoneTypes.TOUCHSTONES_FETCHED_FOR_GROUP, data: [testTouchstone]},
                 {type: DiseasesTypes.DISEASES_FETCHED, data: [testDisease]},
                 {type: TouchstoneTypes.SET_CURRENT_TOUCHSTONE_VERSION, data: testTouchstoneVersion},
                 {type: ResponsibilitiesTypes.SET_RESPONSIBILITIES, data: testExtResponsibilitySet},

--- a/app/src/test/contrib/actions/pages/ResponsibilityOverviewPageActionsTests.ts
+++ b/app/src/test/contrib/actions/pages/ResponsibilityOverviewPageActionsTests.ts
@@ -13,8 +13,8 @@ import {
     mockResponsibilitySet,
     mockTouchstone
 } from "../../../mocks/mockModels";
-import {TouchstonesService} from "../../../../main/contrib/services/TouchstonesService";
-import {TouchstoneTypes} from "../../../../main/contrib/actionTypes/TouchstonesTypes";
+import {TouchstonesService} from "../../../../main/shared/services/TouchstonesService";
+import {TouchstoneTypes} from "../../../../main/shared/actionTypes/TouchstonesTypes";
 import {responsibilityOverviewPageActionCreators} from "../../../../main/contrib/actions/pages/responsibilityOverviewPageActionCreators";
 import {DiseasesService} from "../../../../main/contrib/services/DiseasesService";
 import {ResponsibilitiesService} from "../../../../main/contrib/services/ResponsibilitiesService";
@@ -69,7 +69,7 @@ describe("Responsibility Overview Page actions tests", () => {
             const expectedPayload = [
                 {type: ModellingGroupTypes.USER_GROUPS_FETCHED, data: [testGroup]},
                 {type: ModellingGroupTypes.SET_CURRENT_USER_GROUP, data: testGroup},
-                {type: TouchstoneTypes.TOUCHSTONES_FETCHED, data: [testTouchstone]},
+                {type: TouchstoneTypes.TOUCHSTONES_FETCHED_FOR_GROUP, data: [testTouchstone]},
                 {type: DiseasesTypes.DISEASES_FETCHED, data: [testDisease]},
                 {type: TouchstoneTypes.SET_CURRENT_TOUCHSTONE_VERSION, data: testTouchstoneVersion},
                 {type: ResponsibilitiesTypes.SET_RESPONSIBILITIES, data: testExtResponsibilitySet},

--- a/app/src/test/contrib/actions/pages/UploadBurdenEstimatesPageActionsTests.ts
+++ b/app/src/test/contrib/actions/pages/UploadBurdenEstimatesPageActionsTests.ts
@@ -10,8 +10,8 @@ import {
     mockBreadcrumbs, mockBurdenEstimateSet, mockDisease, mockModellingGroup, mockResponsibilitySet, mockTouchstone,
     mockTouchstoneVersion
 } from "../../../mocks/mockModels";
-import {TouchstonesService} from "../../../../main/contrib/services/TouchstonesService";
-import {TouchstoneTypes} from "../../../../main/contrib/actionTypes/TouchstonesTypes";
+import {TouchstonesService} from "../../../../main/shared/services/TouchstonesService";
+import {TouchstoneTypes} from "../../../../main/shared/actionTypes/TouchstonesTypes";
 import {DiseasesService} from "../../../../main/contrib/services/DiseasesService";
 import {ResponsibilitiesService} from "../../../../main/contrib/services/ResponsibilitiesService";
 import {DiseasesTypes} from "../../../../main/contrib/actionTypes/DiseasesTypes";
@@ -82,7 +82,7 @@ describe("Upload burden estimates page actions tests", () => {
             const expectedPayload = [
                 { type: ModellingGroupTypes.USER_GROUPS_FETCHED, data: [testGroup] },
                 { type: ModellingGroupTypes.SET_CURRENT_USER_GROUP, data: testGroup },
-                { type: TouchstoneTypes.TOUCHSTONES_FETCHED, data: [testTouchstone]},
+                { type: TouchstoneTypes.TOUCHSTONES_FETCHED_FOR_GROUP, data: [testTouchstone]},
                 { type: DiseasesTypes.DISEASES_FETCHED, data: [testDisease]},
                 { type: TouchstoneTypes.SET_CURRENT_TOUCHSTONE_VERSION, data: testTouchstoneVersion},
                 { type: ResponsibilitiesTypes.SET_RESPONSIBILITIES, data: testExtResponsibilitySet},

--- a/app/src/test/contrib/reducers/ContribTouchstonesReducerTests.ts
+++ b/app/src/test/contrib/reducers/ContribTouchstonesReducerTests.ts
@@ -1,35 +1,35 @@
 import { expect } from "chai";
 
-import {touchstonesInitialState, touchstonesReducer} from "../../../main/contrib/reducers/touchstonesReducer";
-import { TouchstoneTypes } from "../../../main/contrib/actionTypes/TouchstonesTypes";
+import {touchstonesInitialState, contribTouchstonesReducer} from "../../../main/contrib/reducers/contribTouchstonesReducer";
+import { TouchstoneTypes } from "../../../main/shared/actionTypes/TouchstonesTypes";
 import {mockTouchstone, mockTouchstoneVersion} from "../../mocks/mockModels";
 
-describe('Touchstones reducer tests', () => {
+describe('Contrib touchstones reducer tests', () => {
     it('sets fetched touchstones', () => {
         const testTouchstone = mockTouchstone();
-        expect(touchstonesReducer(undefined, {
-            type: TouchstoneTypes.TOUCHSTONES_FETCHED,
+        expect(contribTouchstonesReducer(undefined, {
+            type: TouchstoneTypes.TOUCHSTONES_FETCHED_FOR_GROUP,
             data: [testTouchstone]
         })).to.eql({...touchstonesInitialState, touchstones: [testTouchstone]});
     });
 
     it('sets empty fetched touchstones', () => {
-        expect(touchstonesReducer(undefined, {
-            type: TouchstoneTypes.TOUCHSTONES_FETCHED,
+        expect(contribTouchstonesReducer(undefined, {
+            type: TouchstoneTypes.TOUCHSTONES_FETCHED_FOR_GROUP,
             data: null
         })).to.eql(touchstonesInitialState);
     });
 
     it('sets current touchstone', () => {
         const testTouchstoneVersion = mockTouchstoneVersion();
-        expect(touchstonesReducer(undefined, {
+        expect(contribTouchstonesReducer(undefined, {
             type: TouchstoneTypes.SET_CURRENT_TOUCHSTONE_VERSION,
             data: testTouchstoneVersion
         })).to.eql({...touchstonesInitialState, currentTouchstoneVersion: testTouchstoneVersion});
     });
 
     it('sets current touchstone empty', () => {
-        expect(touchstonesReducer(undefined, {
+        expect(contribTouchstonesReducer(undefined, {
             type: TouchstoneTypes.SET_CURRENT_TOUCHSTONE_VERSION,
             data: null
         })).to.eql(touchstonesInitialState);

--- a/app/src/test/mocks/mockStates.ts
+++ b/app/src/test/mocks/mockStates.ts
@@ -14,7 +14,7 @@ import {usersInitialState as adminUsersInitialState} from "../../main/admin/redu
 import {UsersState as AdminUsersState} from "../../main/admin/reducers/usersReducer";
 import {BreadcrumbsState, initialBreadcrumbsState} from "../../main/shared/reducers/breadcrumbsReducer";
 import {ContribAppState} from "../../main/contrib/reducers/contribAppReducers";
-import {touchstonesInitialState, TouchstonesState} from "../../main/contrib/reducers/touchstonesReducer";
+import {touchstonesInitialState, TouchstonesState} from "../../main/contrib/reducers/contribTouchstonesReducer";
 import {responsibilitiesInitialState, ResponsibilitiesState} from "../../main/contrib/reducers/responsibilitiesReducer";
 import {diseasesInitialState, DiseasesState} from "../../main/contrib/reducers/diseasesReducer";
 import {demographicInitialState, DemographicState} from "../../main/contrib/reducers/demographicReducer";

--- a/app/src/test/shared/services/TouchstonesServiceTests.ts
+++ b/app/src/test/shared/services/TouchstonesServiceTests.ts
@@ -2,7 +2,7 @@ import { expect } from "chai";
 import { createMemoryHistory } from 'history';
 
 import {createContribStore} from "../../../main/contrib/createStore";
-import {TouchstonesService} from "../../../main/contrib/services/TouchstonesService";
+import {TouchstonesService} from "../../../main/shared/services/TouchstonesService";
 import {Sandbox} from "../../Sandbox";
 import {ContribAppState} from "../../../main/contrib/reducers/contribAppReducers";
 


### PR DESCRIPTION
https://vimc.myjetbrains.com/youtrack/issue/VIMC-148

A preliminary refactor to move the `TouchstoneService` and `TouchstoneTypes` into the shared space, and to rename `touchstoneActionCreators` and `touchstoneReducer` to have a `contrib` prefix.