### PR TITLE
use compressed token as one time token for report endpoints

### DIFF
--- a/app/src/main/report/actions/OneTimeTokenActions.ts
+++ b/app/src/main/report/actions/OneTimeTokenActions.ts
@@ -15,7 +15,7 @@ class OneTimeTokenActions extends FetchActions<string[]> implements Actions {
     }
 
     receiveToken(token: string): OneTimeToken {
-        return decodeOneTimeToken(jwtTokenAuth.inflateToken(token));
+        return decodeOneTimeToken(token);
     }
 
     clearUsedToken(url: string): string {

--- a/app/src/main/report/models/OneTimeToken.ts
+++ b/app/src/main/report/models/OneTimeToken.ts
@@ -1,3 +1,5 @@
+import {jwtTokenAuth} from "../../shared/modules/jwtTokenAuth";
+
 const jwt_decode = require('jwt-decode');
 
 export interface OneTimeToken {
@@ -15,16 +17,17 @@ export interface OneTimeTokenData {
     nonce: string;
 }
 
-export function decodeOneTimeToken(token: string): OneTimeToken {
+export function decodeOneTimeToken(compressedToken: string): OneTimeToken {
     try {
+        const token = jwtTokenAuth.inflateToken(compressedToken);
         return {
-            raw: token,
+            raw: compressedToken,
             data: jwt_decode(token),
         };
     } catch (e) {
-        console.log("Onetime token decoding failed, token is malformed: " + token);
+        console.log("Onetime token decoding failed, token is malformed: " + compressedToken);
         return {
-            raw: token,
+            raw: compressedToken,
             data: emptyOneTimeTokenData()
         };
     }

--- a/app/src/main/report/stores/OneTimeTokenStore.ts
+++ b/app/src/main/report/stores/OneTimeTokenStore.ts
@@ -61,7 +61,6 @@ class OneTimeTokenStore extends AbstractStore<OneTimeTokenStoreState, OneTimeTok
     }
 
     handleReceiveToken(token: OneTimeToken){
-        console.log(token)
         this.tokens[token.data.url] = token;
     }
 

--- a/app/src/main/report/stores/OneTimeTokenStore.ts
+++ b/app/src/main/report/stores/OneTimeTokenStore.ts
@@ -61,6 +61,7 @@ class OneTimeTokenStore extends AbstractStore<OneTimeTokenStoreState, OneTimeTok
     }
 
     handleReceiveToken(token: OneTimeToken){
+        console.log(token)
         this.tokens[token.data.url] = token;
     }
 

--- a/app/src/test/report/fetch/OneTimeTokenFetchTests.ts
+++ b/app/src/test/report/fetch/OneTimeTokenFetchTests.ts
@@ -14,7 +14,7 @@ describe("OneTimeTokenStore.fetchToken", () => {
     const data = mockOneTimeTokenData({ url: qualifiedUrl });
     const token = sign(data, "secret");
     const compressedToken = compress(token);
-    const decodedToken = decodeOneTimeToken(token);
+    const decodedToken = decodeOneTimeToken(compressedToken);
 
     new ReportingFetchHelper<string, OneTimeToken>({
         makePayload: () => compressedToken,
@@ -28,7 +28,7 @@ describe("OneTimeTokenStore.fetchToken", () => {
         prepareForCachedFetch: () => {
             const tokens: any = {};
             tokens[qualifiedUrl] = {
-                raw: token,
+                raw: compressedToken,
                 data: data
             };
             alt.bootstrap(JSON.stringify({

--- a/app/src/test/report/stores/OnetimeTokenStoreTests.ts
+++ b/app/src/test/report/stores/OnetimeTokenStoreTests.ts
@@ -19,12 +19,12 @@ describe("OneTimeTokenStore", () => {
         oneTimeTokenActions.receiveToken(compressedToken);
         const retrieved = oneTimeTokenStore.getToken(oneTimeTokenStore.getState(), url);
         expect(retrieved).to.not.be.null;
-        expect(retrieved.raw).to.eq(uncompressedToken);
+        expect(retrieved.raw).to.eq(compressedToken);
         expect(retrieved.data.url).to.eq(qualifiedUrl);
     });
 
     it("handles beginFetchToken", () => {
-        bootstrapOneTimeTokenStore([ decodeOneTimeToken(uncompressedToken) ], qualifiedUrl);
+        bootstrapOneTimeTokenStore([ decodeOneTimeToken(compressedToken) ], qualifiedUrl);
         let retrieved = oneTimeTokenStore.getToken(oneTimeTokenStore.getState(), url);
         expect(retrieved.data.url).to.eq(qualifiedUrl);
         oneTimeTokenActions.beginFetchToken();
@@ -33,7 +33,7 @@ describe("OneTimeTokenStore", () => {
     });
 
     it("handles clearUsedToken", () => {
-        bootstrapOneTimeTokenStore([ decodeOneTimeToken(uncompressedToken   ) ]);
+        bootstrapOneTimeTokenStore([ decodeOneTimeToken(compressedToken) ]);
         let retrieved = oneTimeTokenStore.getToken(oneTimeTokenStore.getState(), url);
         expect(retrieved.data.url).to.eq(qualifiedUrl);
         oneTimeTokenActions.clearUsedToken(url);


### PR DESCRIPTION
We were inflating the reporting API's one time token before passing it back in requests, defeating the whole object of the compressed token!

Note that with the changes made here and in VIMC-1938 and VIMC-1942, we are now storing the compressed token in local storage and in the altjs store, which may make debugging slightly harder in the event that something goes wrong and we want to inspect those tokens. I don't think it's a big deal for now, but if we do find this inconveniencing us down the line we could store both the compressed and the decompressed token each time.