### PR TITLE
migrate contrib page action creators to new style

### DIFF
--- a/app/src/main/contrib/ContribPage.tsx
+++ b/app/src/main/contrib/ContribPage.tsx
@@ -1,0 +1,10 @@
+import * as React from "react"
+
+import {ContribAppState} from "./reducers/contribAppReducers";
+import {AbstractPageActionCreators} from "../shared/actions/AbstractPageActionCreators";
+import {Page} from "../shared/components/Page";
+
+
+export function ContribPage<TLocationProps>(pageActionCreators: AbstractPageActionCreators<ContribAppState, TLocationProps>) {
+    return Page<ContribAppState, TLocationProps>(pageActionCreators)
+}

--- a/app/src/main/contrib/actions/pages/ContribPageActionCreators.ts
+++ b/app/src/main/contrib/actions/pages/ContribPageActionCreators.ts
@@ -1,0 +1,6 @@
+import {AbstractPageActionCreators} from "../../../shared/actions/AbstractPageActionCreators";
+import {ContribAppState} from "../../reducers/contribAppReducers";
+
+export abstract class ContribPageActionCreators<TProps> extends AbstractPageActionCreators<ContribAppState, TProps> {
+
+}

--- a/app/src/main/contrib/actions/pages/chooseGroupPageActionCreators.ts
+++ b/app/src/main/contrib/actions/pages/chooseGroupPageActionCreators.ts
@@ -1,23 +1,28 @@
-import { Dispatch } from "redux";
+import {Dispatch} from "redux";
 
-import { modellingGroupsActionCreators } from "../modellingGroupsActionCreators";
+import {modellingGroupsActionCreators} from "../modellingGroupsActionCreators";
 import {ChooseGroupPageComponent} from "../../components/ChooseGroup/ChooseGroupPage";
-import {breadcrumbsActionCreators} from "../../../shared/actions/breadcrumbsActionsCreators";
 import {ContribAppState} from "../../reducers/contribAppReducers";
+import {ContribPageActionCreators} from "./ContribPageActionCreators";
 
-export const chooseGroupPageActionCreators = {
 
-    onLoad() {
-        return async (dispatch: Dispatch<ContribAppState>) => {
-            await dispatch(this.loadData());
-            dispatch(breadcrumbsActionCreators.createBreadcrumbs(ChooseGroupPageComponent.breadcrumb()));
+class ChooseGroupPageActionCreators extends ContribPageActionCreators<{}> {
+
+    parent: null;
+
+    createBreadcrumb() {
+        return {
+            name: ChooseGroupPageComponent.title,
+            urlFragment: "/"
         }
-    },
+    }
 
     loadData() {
         return async (dispatch: Dispatch<ContribAppState>) => {
             await dispatch(modellingGroupsActionCreators.getUserGroups());
         }
     }
+}
 
-};
+
+export const chooseGroupPageActionCreators = new ChooseGroupPageActionCreators();

--- a/app/src/main/contrib/components/ChooseGroup/ChooseGroupPage.tsx
+++ b/app/src/main/contrib/components/ChooseGroup/ChooseGroupPage.tsx
@@ -1,21 +1,14 @@
 import * as React from "react";
-import { compose } from "recompose";
-import { connect } from 'react-redux';
-import { Dispatch } from "redux";
 
 import {ChooseGroupContent} from "./ChooseGroupContent";
 import {PageArticle} from "../../../shared/components/PageWithHeader/PageArticle";
 import {PageBreadcrumb, PageProperties} from "../../../shared/components/PageWithHeader/PageWithHeader";
-import {chooseGroupPageActionCreators} from "../../actions/pages/chooseGroupPageActionCreators";
-import {ContribAppState} from "../../reducers/contribAppReducers";
+import {chooseGroupPageActionCreators} from "../../actions/pages/chooseGroupPageActionCreators"
+import {ContribPage} from "../../ContribPage";
 
 export class ChooseGroupPageComponent extends React.Component<PageProperties<undefined>> {
 
     static title: string = "Modellers' contribution portal";
-
-    componentDidMount(){
-        this.props.onLoad()
-    }
 
     static breadcrumb() : PageBreadcrumb {
         return {
@@ -41,12 +34,4 @@ export class ChooseGroupPageComponent extends React.Component<PageProperties<und
     }
 }
 
-export const mapDispatchToProps = (dispatch: Dispatch<ContribAppState>): Partial<PageProperties<undefined>> => {
-    return {
-        onLoad: () => dispatch(chooseGroupPageActionCreators.onLoad())
-    }
-};
-
-export const ChooseGroupPage = compose(
-    connect(state => state, mapDispatchToProps)
-)(ChooseGroupPageComponent) as React.ComponentClass<Partial<PageProperties<undefined>>>;
+export const ChooseGroupPage = ContribPage(chooseGroupPageActionCreators)(ChooseGroupPageComponent);

--- a/app/src/main/report/components/OneTimeLinkContext.tsx
+++ b/app/src/main/report/components/OneTimeLinkContext.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import {OneTimeToken} from "../models/OneTimeToken";
 import {connect, Dispatch} from "react-redux";
 import {ReportAppState} from "../reducers/reportAppReducers";
 import {oneTimeTokenActionCreators} from "../actionCreators/oneTimeTokenActionCreators";

--- a/app/src/main/shared/components/Page.tsx
+++ b/app/src/main/shared/components/Page.tsx
@@ -16,9 +16,6 @@ export function Page<TState, TLocationProps>(pageActionCreators: AbstractPageAct
 
     const lifecycleMethods: Partial<LifecycleMethods<PageProperties<TLocationProps>>> = {
         onWillMount(props: PageProperties<TLocationProps>) {
-
-            console.log("-----------------------------------------------------------")
-            console.log(props)
             props.onLoad(props.match.params)
         }
     };

--- a/app/src/main/shared/components/Page.tsx
+++ b/app/src/main/shared/components/Page.tsx
@@ -1,0 +1,26 @@
+import * as React from "react"
+import {connect} from "react-redux";
+import {Dispatch} from "redux";
+import {compose} from "recompose";
+import withLifecycle, {LifecycleMethods} from "@hocs/with-lifecycle";
+import {AbstractPageActionCreators} from "../actions/AbstractPageActionCreators";
+import {PageProperties} from "./PageWithHeader/PageWithHeader";
+
+export function Page<TState, TLocationProps>(pageActionCreators: AbstractPageActionCreators<TState, TLocationProps>) {
+
+    const mapDispatchToProps = (dispatch: Dispatch<TState>): Partial<PageProperties<TLocationProps>> => {
+        return {
+            onLoad: (params: TLocationProps) => dispatch(pageActionCreators.onLoad(params))
+        }
+    };
+
+    const lifecycleMethods: Partial<LifecycleMethods<PageProperties<TLocationProps>>> = {
+        onWillMount(props: PageProperties<TLocationProps>) {
+            props.onLoad(props.match.params)
+        }
+    };
+
+    return compose<PageProperties<TLocationProps>, {}>(
+        connect(() => {}, mapDispatchToProps),
+        withLifecycle(lifecycleMethods));
+}

--- a/app/src/main/shared/components/Page.tsx
+++ b/app/src/main/shared/components/Page.tsx
@@ -16,11 +16,14 @@ export function Page<TState, TLocationProps>(pageActionCreators: AbstractPageAct
 
     const lifecycleMethods: Partial<LifecycleMethods<PageProperties<TLocationProps>>> = {
         onWillMount(props: PageProperties<TLocationProps>) {
+
+            console.log("-----------------------------------------------------------")
+            console.log(props)
             props.onLoad(props.match.params)
         }
     };
 
-    return compose<PageProperties<TLocationProps>, {}>(
-        connect(() => {}, mapDispatchToProps),
+    return compose<PageProperties<TLocationProps>, Partial<PageProperties<TLocationProps>>>(
+        connect((state: TState, props: TLocationProps) => props, mapDispatchToProps),
         withLifecycle(lifecycleMethods));
 }

--- a/app/src/test/ActionCreatorTestHelpers.ts
+++ b/app/src/test/ActionCreatorTestHelpers.ts
@@ -40,7 +40,7 @@ export function verifyActionThatCallsServiceAndReturnsResult(
     store.dispatch(props.callActionCreator());
     setTimeout(() => {
         const actions = store.getActions();
-        expect(props.expectTheseActionTypes).to.eql(actions.map((x: any) => x.type));
+        expect(actions.map((x: any) => x.type)).to.eql(props.expectTheseActionTypes);
         props.expectTheseActionTypes.forEach((expectedAction, i) => {
             expect(actions[i]).to.eql({
                 type: expectedAction,

--- a/app/src/test/contrib/components/ChooseGroup/ChooseGroupPageTests.tsx
+++ b/app/src/test/contrib/components/ChooseGroup/ChooseGroupPageTests.tsx
@@ -6,8 +6,6 @@ import "../../../helper";
 import { ChooseGroupPage, ChooseGroupPageComponent } from "../../../../main/contrib/components/ChooseGroup/ChooseGroupPage";
 import { Sandbox } from "../../../Sandbox";
 import {createMockStore} from "../../../mocks/mockStore";
-import {chooseGroupPageActionCreators} from "../../../../main/contrib/actions/pages/chooseGroupPageActionCreators";
-import {PageArticle} from "../../../../main/shared/components/PageWithHeader/PageArticle";
 import {ChooseGroupContent} from "../../../../main/contrib/components/ChooseGroup/ChooseGroupContent";
 
 describe("Choose Group Page Component", () => {
@@ -21,13 +19,10 @@ describe("Choose Group Page Component", () => {
         expect(typeof rendered.props().onLoad).is.equal('function');
     });
 
-    it("renders component component level", () => {
-        let store = createMockStore();
-        const onLoadStub = sandbox.setStubReduxAction(chooseGroupPageActionCreators, "onLoad");
-        const rendered = shallow(<ChooseGroupPage/>, {context: {store}}).dive();
+    it("renders title, description and ChooseGroupContent", () => {
+        const rendered = shallow(<ChooseGroupPageComponent history={null} location={null} match={null} router={null}/>);
         const pageArticle = rendered.find('PageArticle');
-        expect(onLoadStub.called).is.equal(true);
-        expect(pageArticle.props().title).is.equal(ChooseGroupPageComponent.title);
+        expect(pageArticle.props().title).is.equal("Modellers' contribution portal");
         expect(pageArticle.find('p').length).is.equal(1);
         expect(pageArticle.find(ChooseGroupContent).length).is.equal(1);
     });

--- a/app/src/test/mocks/mocks.ts
+++ b/app/src/test/mocks/mocks.ts
@@ -1,5 +1,5 @@
 import {Location} from "history";
-import {match} from 'react-router';
+import {match, MemoryRouter, Router, RouterChildContext} from 'react-router';
 
 import {emptyOneTimeTokenData, OneTimeToken, OneTimeTokenData} from "../../main/report/models/OneTimeToken";
 
@@ -12,7 +12,7 @@ export function mockLocation(params?: Partial<Location>): Location {
     }, params);
 }
 
-export function mockMatch<P>(params?: P) :match<P> {
+export function mockMatch<P>(params?: P): match<P> {
     return {
         params: params || null,
         isExact: true,
@@ -26,14 +26,22 @@ export function mockHistory(params?: any) {
         length: 1,
         action: "",
         location: "",
-        push: () => {},
-        replace: () => {},
-        go: () => {},
-        goBack: () => {},
-        goForward: () => {},
-        block: () => {},
-        listen: () => {},
-        createHref: () => {}
+        push: () => {
+        },
+        replace: () => {
+        },
+        go: () => {
+        },
+        goBack: () => {
+        },
+        goForward: () => {
+        },
+        block: () => {
+        },
+        listen: () => {
+        },
+        createHref: () => {
+        }
     }, params);
 }
 
@@ -51,7 +59,7 @@ export function mockOneTimeTokenData(props: any): OneTimeTokenData {
 export function mockOneTimeToken(url: string): OneTimeToken {
     return {
         raw: "TOKEN",
-        data: mockOneTimeTokenData({ url: url })
+        data: mockOneTimeTokenData({url: url})
     };
 }
 

--- a/app/src/test/mocks/mocks.ts
+++ b/app/src/test/mocks/mocks.ts
@@ -1,5 +1,5 @@
 import {Location} from "history";
-import {match, MemoryRouter, Router, RouterChildContext} from 'react-router';
+import {match} from 'react-router';
 
 import {emptyOneTimeTokenData, OneTimeToken, OneTimeTokenData} from "../../main/report/models/OneTimeToken";
 
@@ -12,7 +12,7 @@ export function mockLocation(params?: Partial<Location>): Location {
     }, params);
 }
 
-export function mockMatch<P>(params?: P): match<P> {
+export function mockMatch<P>(params?: P) :match<P> {
     return {
         params: params || null,
         isExact: true,
@@ -26,22 +26,14 @@ export function mockHistory(params?: any) {
         length: 1,
         action: "",
         location: "",
-        push: () => {
-        },
-        replace: () => {
-        },
-        go: () => {
-        },
-        goBack: () => {
-        },
-        goForward: () => {
-        },
-        block: () => {
-        },
-        listen: () => {
-        },
-        createHref: () => {
-        }
+        push: () => {},
+        replace: () => {},
+        go: () => {},
+        goBack: () => {},
+        goForward: () => {},
+        block: () => {},
+        listen: () => {},
+        createHref: () => {}
     }, params);
 }
 
@@ -59,7 +51,7 @@ export function mockOneTimeTokenData(props: any): OneTimeTokenData {
 export function mockOneTimeToken(url: string): OneTimeToken {
     return {
         raw: "TOKEN",
-        data: mockOneTimeTokenData({url: url})
+        data: mockOneTimeTokenData({ url: url })
     };
 }
 

--- a/app/src/test/shared/components/PageTests.tsx
+++ b/app/src/test/shared/components/PageTests.tsx
@@ -1,0 +1,64 @@
+import * as React from "react";
+import {expect} from "chai";
+import "../../helper";
+import {
+    PageBreadcrumb,
+    PageProperties,
+} from "../../../main/shared/components/PageWithHeader/PageWithHeader";
+import {Sandbox} from "../../Sandbox";
+import {checkAsync} from "../../testHelpers";
+import {Page} from "../../../main/shared/components/Page";
+import {AbstractPageActionCreators} from "../../../main/shared/actions/AbstractPageActionCreators";
+import {Dispatch} from "redux";
+import {shallow} from "enzyme";
+import {createMockAdminStore} from "../../mocks/mockStore";
+import {mockMatch} from "../../mocks/mocks";
+import {BreadcrumbsTypes} from "../../../main/shared/actionTypes/BreadrumbsTypes";
+import {mockPageBreadcrumb} from "../../mocks/mockModels";
+
+class DummyPageComponent extends React.Component<PageProperties<undefined>> {
+    render(): JSX.Element {
+        return <div>Some content</div>
+    }
+}
+
+const fakeAction = {type: "fake-action", data: "fake-data"};
+const fakeBreadcrumbs = mockPageBreadcrumb();
+
+class DummyPageActionCreators extends AbstractPageActionCreators<any, any> {
+
+    parent: AbstractPageActionCreators<any, any> = null;
+
+    createBreadcrumb(state: any): PageBreadcrumb {
+        return fakeBreadcrumbs
+    }
+
+    loadData(params: any): (dispatch: Dispatch<any>, getState: () => any) => void {
+        return (dispatch: Dispatch<any>) => {
+            dispatch(fakeAction)
+        }
+    }
+}
+
+const dummyPageActionCreators = new DummyPageActionCreators();
+const DummyPage = Page(dummyPageActionCreators)(DummyPageComponent);
+
+describe('Page HOC', () => {
+    const sandbox = new Sandbox();
+
+    afterEach(() => sandbox.restore());
+
+    it("loads on mount", (done: DoneCallback) => {
+        const store = createMockAdminStore({auth: {loggedIn: true}});
+        shallow(<DummyPage match={mockMatch()}/>, {context: {store}})
+            .dive().dive();
+
+        checkAsync(done, () => {
+            const actions = store.getActions();
+
+            const expectedActionTypes = [BreadcrumbsTypes.BREADCRUMBS_RECEIVED, fakeAction.type];
+            expect(actions.map(a => a.type)).to.have.members(expectedActionTypes);
+        });
+    });
+
+});


### PR DESCRIPTION
This refactors the top-level page in the Contrib portal, `ChooseActionPage`, to use the new `AbstractPageActionCreators` class, and also adds a new HOC that can be used to hook up an instance of the `AbstractPageActionCreators` class to a page component by automatically calling the former's `onLoad` method when the component mounts.