### PR TITLE
Weirdbug

### DIFF
--- a/app/src/test/contrib/components/Responsibilities/Coverage/DownloadCoverageContentTests.tsx
+++ b/app/src/test/contrib/components/Responsibilities/Coverage/DownloadCoverageContentTests.tsx
@@ -99,11 +99,14 @@ describe("Download Coverage Content Component", () => {
     });
 
 
-    it("renders on component level touchstone and scenario table", () => {
+    it("renders on component level touchstone and scenario table", (done: DoneCallback) => {
         const rendered = shallow(<DownloadCoverageContent/>, {context: {store}}).dive().dive().dive().dive().dive();
         const firstTable = rendered.find('table.specialColumn').at(0);
-        expect(firstTable.find('tr').at(0).find('div.col').at(1).text(), testTouchstone.description);
-   //     expect(firstTable.find('tr').at(1).find('div.col').at(1).text(), testScenario.description);
+        setTimeout(() => {
+            expect(firstTable.find('tr').at(0).find('div.col').at(1).text(), testTouchstone.description);
+            expect(firstTable.find('tr').at(1).find('div.col').at(1).text(), testScenario.description);
+            done()
+        })
     });
 
     it("renders on component level coverage set list and format control", () => {

--- a/app/src/test/contrib/components/Responsibilities/Coverage/DownloadCoverageContentTests.tsx
+++ b/app/src/test/contrib/components/Responsibilities/Coverage/DownloadCoverageContentTests.tsx
@@ -45,7 +45,7 @@ describe("Download Coverage Content Component", () => {
         user: {signedConfidentialityAgreement: false}
     };
 
-    let store : Store<ContribAppState>;
+    let store: Store<ContribAppState>;
 
     const sandbox = new Sandbox();
     beforeEach(() => {
@@ -98,15 +98,14 @@ describe("Download Coverage Content Component", () => {
         expect(rendered.find(ConfidentialityAgreementComponent).length).to.eql(1);
     });
 
-
-    it("renders on component level touchstone and scenario table", (done: DoneCallback) => {
+    it("renders on component level touchstone and scenario table", () => {
         const rendered = shallow(<DownloadCoverageContent/>, {context: {store}}).dive().dive().dive().dive().dive();
         const firstTable = rendered.find('table.specialColumn').at(0);
-        setTimeout(() => {
-            expect(firstTable.find('tr').at(0).find('div.col').at(1).text(), testTouchstone.description);
-            expect(firstTable.find('tr').at(1).find('div.col').at(1).text(), testScenario.description);
-            done()
-        })
+        console.log("firstTable: " + firstTable.debug());
+        console.log("0th tr: " + firstTable.find('tr').at(0).debug());
+        console.log("0th tr, 1st col: " + firstTable.find('tr').at(0).find('div.col').at(1));
+        expect(firstTable.find('tr').at(0).find('div.col').at(1).text(), testTouchstone.description);
+        expect(firstTable.find('tr').at(1).find('div.col').at(1).text(), testScenario.description);
     });
 
     it("renders on component level coverage set list and format control", () => {
@@ -148,7 +147,7 @@ describe("Download Coverage Content Component", () => {
 
     it("calling onSelectFormat triggers both get token and set format actions", () => {
         const rendered = shallow(<DownloadCoverageContent/>, {context: {store}}).dive().dive().dive()
-        .dive().dive().dive();
+            .dive().dive().dive();
         const downloadCoverageContentComponentInstance = rendered.instance() as DownloadCoverageContentComponent;
         const onLoadTokenStub = sandbox.setStubReduxAction(coverageActionCreators, "getOneTimeToken");
         const onFormatSelectStub = sandbox.setStubReduxAction(coverageActionCreators, "setFormat");

--- a/app/src/test/contrib/components/Responsibilities/Coverage/DownloadCoverageContentTests.tsx
+++ b/app/src/test/contrib/components/Responsibilities/Coverage/DownloadCoverageContentTests.tsx
@@ -101,7 +101,7 @@ describe("Download Coverage Content Component", () => {
     it("renders on component level touchstone and scenario table", () => {
         const rendered = shallow(<DownloadCoverageContent/>, {context: {store}}).dive().dive().dive().dive().dive();
         console.log("rendered: " + rendered.debug());
-        console.log("table: " + rendered.find('table.specialColumn'));
+        console.log("table: " + rendered.find('table.specialColumn').debug());
         const firstTable = rendered.find('table.specialColumn').at(0);
         console.log("firstTable: " + firstTable.debug());
         console.log("0th tr: " + firstTable.find('tr').at(0).debug());

--- a/app/src/test/contrib/components/Responsibilities/Coverage/DownloadCoverageContentTests.tsx
+++ b/app/src/test/contrib/components/Responsibilities/Coverage/DownloadCoverageContentTests.tsx
@@ -99,13 +99,19 @@ describe("Download Coverage Content Component", () => {
     });
 
     it("renders on component level touchstone and scenario table", () => {
-        const rendered = shallow(<DownloadCoverageContent/>, {context: {store}}).dive().dive().dive().dive().dive();
+        const rendered = shallow(<DownloadCoverageContent/>, {context: {store}})
+            .dive()
+            .dive()
+            .dive()
+            .dive()
+            .dive()
+            .dive();
         console.log("rendered: " + rendered.debug());
         console.log("table: " + rendered.find('table.specialColumn').debug());
         const firstTable = rendered.find('table.specialColumn').at(0);
         console.log("firstTable: " + firstTable.debug());
         console.log("0th tr: " + firstTable.find('tr').at(0).debug());
-        console.log("0th tr, 1st col: " + firstTable.find('tr').at(0).find('div.col').at(1));
+        console.log("0th tr, 1st col: " + firstTable.find('tr').at(0).find('div.col').at(1).debug());
         expect(firstTable.find('tr').at(0).find('div.col').at(1).text(), testTouchstone.description);
         expect(firstTable.find('tr').at(1).find('div.col').at(1).text(), testScenario.description);
     });

--- a/app/src/test/contrib/components/Responsibilities/Coverage/DownloadCoverageContentTests.tsx
+++ b/app/src/test/contrib/components/Responsibilities/Coverage/DownloadCoverageContentTests.tsx
@@ -100,6 +100,8 @@ describe("Download Coverage Content Component", () => {
 
     it("renders on component level touchstone and scenario table", () => {
         const rendered = shallow(<DownloadCoverageContent/>, {context: {store}}).dive().dive().dive().dive().dive();
+        console.log("rendered: " + rendered.debug());
+        console.log("table: " + rendered.find('table.specialColumn'));
         const firstTable = rendered.find('table.specialColumn').at(0);
         console.log("firstTable: " + firstTable.debug());
         console.log("0th tr: " + firstTable.find('tr').at(0).debug());

--- a/app/src/test/contrib/components/Responsibilities/Coverage/DownloadCoverageContentTests.tsx
+++ b/app/src/test/contrib/components/Responsibilities/Coverage/DownloadCoverageContentTests.tsx
@@ -100,18 +100,8 @@ describe("Download Coverage Content Component", () => {
 
     it("renders on component level touchstone and scenario table", () => {
         const rendered = shallow(<DownloadCoverageContent/>, {context: {store}})
-            .dive()
-            .dive()
-            .dive()
-            .dive()
-            .dive()
-            .dive();
-        console.log("rendered: " + rendered.debug());
-        console.log("table: " + rendered.find('table.specialColumn').debug());
+            .dive().dive().dive().dive().dive().dive();
         const firstTable = rendered.find('table.specialColumn').at(0);
-        console.log("firstTable: " + firstTable.debug());
-        console.log("0th tr: " + firstTable.find('tr').at(0).debug());
-        console.log("0th tr, 1st col: " + firstTable.find('tr').at(0).find('div.col').at(1).debug());
         expect(firstTable.find('tr').at(0).find('div.col').at(1).text(), testTouchstone.description);
         expect(firstTable.find('tr').at(1).find('div.col').at(1).text(), testScenario.description);
     });


### PR DESCRIPTION
So it looks like we needed one more `dive`. I'm not sure why this changed.

However, it general I think it's pretty terrible all this "do we want 4 dives or 5 or 6" nonsense. Could we write some kind of `.diveUntilYouFindSomeHTML()` function? That would handle a bunch of cases, although sadly not all. Maybe `diveUntilIsPresent(SomeComponent)`?