### PR TITLE
I2042 alex suggestions

### DIFF
--- a/app/src/main/contrib/components/Responsibilities/Demographics/DownloadDemographicsContent.tsx
+++ b/app/src/main/contrib/components/Responsibilities/Demographics/DownloadDemographicsContent.tsx
@@ -22,7 +22,10 @@ export class DownloadDemographicsContentComponent extends React.Component<Downlo
         const {touchstone, selectedDataSet, selectedFormat, selectedGender} = this.props;
         let url: string = null;
         if (canDownload) {
-            url = `/touchstones/${touchstone.id}/demographics/${selectedDataSet.source}/${selectedDataSet.id}/?format=${selectedFormat}&gender=${selectedGender}`;
+            url = `/touchstones/${touchstone.id}/demographics/${selectedDataSet.source}/${selectedDataSet.id}/?format=${selectedFormat}`
+            if (this.props.selectedDataSet.gender_is_applicable || this.props.selectedGender != null) {
+                url += `&gender=${selectedGender}`;
+            }
         }
 
         return <div className="demographics">

--- a/app/src/main/contrib/components/Responsibilities/Demographics/DownloadDemographicsContent.tsx
+++ b/app/src/main/contrib/components/Responsibilities/Demographics/DownloadDemographicsContent.tsx
@@ -45,7 +45,6 @@ export class DownloadDemographicsContentComponent extends React.Component<Downlo
             <DemographicOptions/>
             <FileDownloadButton
                 href={url}
-                enabled={canDownload}
                 delayBeforeReenable={5}
             >
                 Download data set

--- a/app/src/main/shared/components/FileDownloadLink.tsx
+++ b/app/src/main/shared/components/FileDownloadLink.tsx
@@ -26,6 +26,7 @@ export class FileDownloadButtonInner extends React.Component<OneTimeLinkProps, u
             className={"button" + (this.props.className ? ` ${this.props.className}` : "")}
             href={this.props.href}
             enabled={this.props.enabled}
+            loading={this.props.loading}
             tokenConsumed={this.props.tokenConsumed}>
             {this.props.children}
             <span className="download-icon">
@@ -47,14 +48,14 @@ export class FileDownloadInner extends React.Component<OneTimeLinkProps, undefin
     }
 
     render() {
-        const {href, enabled} = this.props;
+        const {href, enabled, loading} = this.props;
         let className = this.props.className;
         let loader: JSX.Element = null;
 
         if (href == null || !enabled) {
             className += ' disabled'
         }
-        if (href == null && enabled) {
+        if (loading) {
             loader = <img src={loaderAnimation}/>;
         }
 

--- a/app/src/main/shared/components/OneTimeLinkContext.tsx
+++ b/app/src/main/shared/components/OneTimeLinkContext.tsx
@@ -38,7 +38,6 @@ export interface OneTimeLinkProps extends PropsSharedWithChildren {
 
 interface ComponentState {
     enabled: boolean;
-    loading: boolean;
 }
 
 const mapStateToProps = (state: ReportAppState, props: PublicProps): Partial<Props> => {
@@ -58,7 +57,7 @@ export function OneTimeLinkContext(WrappedComponent: ComponentConstructor<OneTim
 
         constructor(props?: Props) {
             super(props);
-            this.state = {enabled: true, loading: true};
+            this.state = {enabled: true};
         }
 
         componentDidMount() {

--- a/app/src/main/shared/components/OneTimeLinkContext.tsx
+++ b/app/src/main/shared/components/OneTimeLinkContext.tsx
@@ -13,7 +13,6 @@ const url = require('url'),
 interface PropsSharedWithChildren {
     href: string;
     className?: string;
-    enabled?: boolean;
 }
 
 // Props that are passed to the HOC
@@ -33,11 +32,13 @@ interface Props extends PublicProps {
 // These props are passed to the children
 export interface OneTimeLinkProps extends PropsSharedWithChildren {
     enabled: boolean;
+    loading: boolean;
     tokenConsumed: () => void;
 }
 
 interface ComponentState {
     enabled: boolean;
+    loading: boolean;
 }
 
 const mapStateToProps = (state: ReportAppState, props: PublicProps): Partial<Props> => {
@@ -57,7 +58,7 @@ export function OneTimeLinkContext(WrappedComponent: ComponentConstructor<OneTim
 
         constructor(props?: Props) {
             super(props);
-            this.state = {enabled: true};
+            this.state = {enabled: true, loading: true};
         }
 
         componentDidMount() {
@@ -65,7 +66,7 @@ export function OneTimeLinkContext(WrappedComponent: ComponentConstructor<OneTim
         }
 
         componentDidUpdate(prevProps: Props) {
-            if (this.props.href != prevProps.href || this.props.enabled != prevProps.enabled) {
+            if (this.props.href != prevProps.href) {
                 this.refreshToken();
                 this.immediatelyEnable();
             }
@@ -84,7 +85,8 @@ export function OneTimeLinkContext(WrappedComponent: ComponentConstructor<OneTim
             return <WrappedComponent
                 className={this.props.className}
                 href={href}
-                enabled={this.getEnabled() && this.state.enabled}
+                enabled={this.state.enabled}
+                loading={this.props.href != null && this.props.token == null}
                 tokenConsumed={this.tokenConsumed.bind(this)}
                 children={this.props.children}/>;
         }
@@ -110,16 +112,8 @@ export function OneTimeLinkContext(WrappedComponent: ComponentConstructor<OneTim
         }
 
         private refreshToken() {
-            if (this.getEnabled()) {
+            if (this.props.href != null) {
                 this.props.refreshToken(this.props.href, this.getService());
-            }
-        }
-
-        private getEnabled(): boolean {
-            if (isNullOrUndefined(this.props.enabled)) {
-                return true;
-            } else {
-                return this.props.enabled;
             }
         }
 

--- a/app/src/main/shared/components/OneTimeLinkContext.tsx
+++ b/app/src/main/shared/components/OneTimeLinkContext.tsx
@@ -32,7 +32,7 @@ interface Props extends PublicProps {
 // These props are passed to the children
 export interface OneTimeLinkProps extends PropsSharedWithChildren {
     enabled: boolean;
-    loading: boolean;
+    loading?: boolean;
     tokenConsumed: () => void;
 }
 

--- a/app/src/test/shared/components/FileDownloadLinkTests.tsx
+++ b/app/src/test/shared/components/FileDownloadLinkTests.tsx
@@ -25,6 +25,18 @@ describe("FileDownloadLinkInner", () => {
         expect(a.prop('href')).to.equal("/grapefruit");
     });
 
+    it("renders loading animation when loading is true", () => {
+        const rendered = shallow(<FileDownloadInner href="/grapefruit" tokenConsumed={null} enabled={true} loading={true} />);
+        const img = rendered.find("img");
+        expect(img).to.have.lengthOf(1)
+    });
+
+    it("does not render loading animation when loading is false", () => {
+        const rendered = shallow(<FileDownloadInner href={null} tokenConsumed={null} enabled={true} loading={false} />);
+        const img = rendered.find("img");
+        expect(img).to.have.lengthOf(0);
+    });
+
     it("clicking link triggers token refresh", () => {
         let called = false;
         const callback = () => called = true;
@@ -55,7 +67,7 @@ describe("FileDownloadButton", () => {
     });
 
     it("passes through classname if exists", () => {
-        const rendered = shallow(<FileDownloadButtonInner href={null} tokenConsumed={null} className={"test"} enabled={true}/>);
+        const rendered = shallow(<FileDownloadButtonInner href={null} tokenConsumed={null} className={"test"} enabled={true} />);
         const inner = rendered.find(FileDownloadInner);
         expect(inner).to.have.lengthOf(1);
         expect(inner.prop('className')).to.equal("button test");

--- a/app/src/test/shared/components/OneTimeLinkContextTests.tsx
+++ b/app/src/test/shared/components/OneTimeLinkContextTests.tsx
@@ -74,8 +74,8 @@ describe("OneTimeLinkContext", () => {
         });
     });
 
-    it("does not trigger fetchToken if disabled", (done: DoneCallback) => {
-        render(<Class href="/banana/" service="main" enabled={false}/>);
+    it("does not trigger fetchToken if href is null", (done: DoneCallback) => {
+        render(<Class href={null} service="main"/>);
         checkAsync(done, () => {
             expect(fetchTokenStub.notCalled).to.equal(true, "Expected fetchToken to not be called");
         });
@@ -90,7 +90,7 @@ describe("OneTimeLinkContext", () => {
     });
 
     it("triggers fetchToken when wrapped component consumes token", (done: DoneCallback) => {
-        const element = render(<Class href={url} />);
+        const element = render(<Class href={url}/>);
         element.find(EmptyComponent).dive().find("button").simulate("click");
         checkAsync(done, () => {
             expect(fetchTokenStub.calledTwice).to.equal(true, "Expected fetchToken to be called twice");
@@ -124,12 +124,32 @@ describe("OneTimeLinkContext", () => {
         });
     });
 
-    it("triggers fetchToken when becomes enabled", (done: DoneCallback) => {
+    it("triggers fetchToken when href becomes not null", (done: DoneCallback) => {
         const url = "/bamboo";
-        const element = render(<Class href={url} enabled={false}/>);
-        element.setProps({enabled: true});
+        const element = render(<Class href={null}/>);
+        element.setProps({href: url});
         checkAsync(done, () => {
             expect(fetchTokenStub.calledOnce).to.equal(true, "Expected fetchToken to be called once");
+        });
+    });
+
+    it("is loading when href is not null and token is null", () => {
+        const url = "/url-with-no-token";
+        const element = render(<Class href={url}/>);
+        expect(element.find(EmptyComponent).prop("loading")).to.be.true;
+    });
+
+    it("is not loading when href is null", () => {
+        const element = render(<Class href={null}/>);
+        expect(element.find(EmptyComponent).prop("loading")).to.be.false;
+    });
+
+    it("is not loading when token is present", (done: DoneCallback) => {
+        const url = "/bamboo";
+        const element = render(<Class href={url}/>);
+
+        checkAsync(done, () => {
+            expect(element.find(EmptyComponent).prop("loading")).to.be.true;
         });
     });
 
@@ -148,21 +168,6 @@ describe("OneTimeLinkContext", () => {
     });
 
     describe("enablement", () => {
-        it("passes through enable to wrapped component", () => {
-            let element = render(<Class href="/url/" enabled={true}/>);
-            let wrapped = element.find(EmptyComponent);
-            expect(wrapped.prop("enabled")).to.equal(true, "Expected enabled to be true");
-
-            element = render(<Class href="/url/" enabled={false}/>);
-            wrapped = element.find(EmptyComponent);
-            expect(wrapped.prop("enabled")).to.equal(false, "Expected enabled to be false");
-        });
-
-        it("defaults enable to true", () => {
-            const element = render(<Class href="/url/"/>);
-            const wrapped = element.find(EmptyComponent);
-            expect(wrapped.prop("enabled")).to.be.true;
-        });
 
         it("by default, stays enabled after clicking", (done: DoneCallback) => {
             const element = render(<Class href="/url/"/>);
@@ -172,7 +177,7 @@ describe("OneTimeLinkContext", () => {
         });
 
         it("when state.enabled is false, wrapped component is disabled", () => {
-            const element = render(<Class href="/url/" enabled={true}/>);
+            const element = render(<Class href="/url/"/>);
             element.instance().setState({enabled: false});
             element.update();
             expect(element.find(EmptyComponent).prop("enabled")).to.be.false;


### PR DESCRIPTION
Removes `enabled` prop passed to `OnetimeLinkContext` and introduces `loading` prop generated by the HOC and passed to the wrapped component.