### PR TITLE
i2082 - add links to download coverage

### DIFF
--- a/app/src/main/admin/components/Touchstones/Scenarios/ScenarioGroup.tsx
+++ b/app/src/main/admin/components/Touchstones/Scenarios/ScenarioGroup.tsx
@@ -1,10 +1,13 @@
 import * as React from "react";
 import {Disease, Scenario} from "../../../../shared/models/Generated";
 import {UncontrolledTooltip} from "reactstrap";
+import {FileDownloadButton} from "../../../../shared/components/FileDownloadLink";
 
 export interface ScenarioGroupProps {
+    touchstoneVersionId: string;
     disease: Disease;
     scenarios: Scenario[];
+    canDownloadCoverage: boolean;
 }
 
 export class ScenarioGroup extends React.Component<ScenarioGroupProps> {
@@ -12,7 +15,7 @@ export class ScenarioGroup extends React.Component<ScenarioGroupProps> {
         return <div>
             <h3>{this.props.disease.name}</h3>
             <div className="row">
-                <ul className="list-group col-lg-9 col-md-9 col-12">
+                <ul className="list-group col-12">
                     {this.renderRows(this.props.scenarios)}
                 </ul>
             </div>
@@ -20,17 +23,27 @@ export class ScenarioGroup extends React.Component<ScenarioGroupProps> {
     }
 
     renderRows(scenarios: Scenario[]): JSX.Element[] {
-        return scenarios.map(s => <li key={s.id} className="list-group-item">
-            <div className="row align-items-center">
-                <div className="col-4 text-left">{s.description}</div>
-                <code className="col-4 text-center">{s.id}</code>
-                <div className="col-4 text-right">
-                    <button id={`download-coverage-${s.id}`} disabled={true}>Download coverage data</button>
-                    <UncontrolledTooltip placement="bottom" target={`download-coverage-${s.id}`}>
-                        Coming soon
-                    </UncontrolledTooltip>
-                </div>
-            </div>
-        </li>);
+        return scenarios.map(s => ScenarioItem(this.props, s));
     }
 }
+
+const ScenarioItem = (props: ScenarioGroupProps, scenario: Scenario) => {
+    let href = null;
+    if (props.canDownloadCoverage) {
+        href = `/touchstones/${props.touchstoneVersionId}/${scenario.id}/coverage/csv/`
+    }
+    return <li key={scenario.id} className="list-group-item">
+        <div className="row align-items-center">
+            <div className="col-4 text-left">{scenario.description}</div>
+            <code className="col-4 text-center">{scenario.id}</code>
+            <div className="col-4 text-right" id={`download-coverage-${scenario.id}`}>
+                <FileDownloadButton href={href}>
+                    Download coverage data</FileDownloadButton>
+                {!props.canDownloadCoverage &&
+                <UncontrolledTooltip placement="bottom" target={`download-coverage-${scenario.id}`}>
+                    You do not have permission to download coverage
+                </UncontrolledTooltip>}
+            </div>
+        </div>
+    </li>
+};

--- a/app/src/main/admin/components/Touchstones/Scenarios/ScenariosList.tsx
+++ b/app/src/main/admin/components/Touchstones/Scenarios/ScenariosList.tsx
@@ -8,6 +8,8 @@ import {discardDispatch} from "../../../../shared/Helpers";
 export interface ScenariosListProps {
     scenarios: Scenario[];
     diseases: Disease[];
+    canDownloadCoverage: boolean;
+    touchstoneVersionId: string;
 }
 
 export class ScenariosListComponent extends React.Component<ScenariosListProps> {
@@ -16,7 +18,9 @@ export class ScenariosListComponent extends React.Component<ScenariosListProps> 
             {this.props.diseases.map(disease => <ScenarioGroup
                 key={disease.id}
                 disease={disease}
+                canDownloadCoverage={this.props.canDownloadCoverage}
                 scenarios={this.props.scenarios.filter(s => s.disease == disease.id)}
+                touchstoneVersionId={this.props.touchstoneVersionId}
             />)}
         </div>;
     }
@@ -25,7 +29,10 @@ export class ScenariosListComponent extends React.Component<ScenariosListProps> 
 function mapStateToProps(state: AdminAppState): ScenariosListProps {
     return {
         scenarios: state.scenario.scenarios,
-        diseases: state.diseases.diseases
+        diseases: state.diseases.diseases,
+        canDownloadCoverage: state.auth.permissions.indexOf("*/coverage.read") > -1,
+        touchstoneVersionId: state.touchstones.currentTouchstoneVersion ? state.touchstones.currentTouchstoneVersion.id
+            : null
     }
 }
 

--- a/app/src/test/admin/components/Touchstones/Scenarios/ScenarioGroupTests.tsx
+++ b/app/src/test/admin/components/Touchstones/Scenarios/ScenarioGroupTests.tsx
@@ -6,10 +6,14 @@ import {
     ScenarioGroup,
     ScenarioGroupProps
 } from "../../../../../main/admin/components/Touchstones/Scenarios/ScenarioGroup";
+import {FileDownloadButton} from "../../../../../main/shared/components/FileDownloadLink";
+import {UncontrolledTooltip} from "reactstrap";
 
 describe("ScenarioGroup", () => {
     it("renders one row per scenario", () => {
         const props: ScenarioGroupProps = {
+            touchstoneVersionId: "t1",
+            canDownloadCoverage: true,
             disease: mockDisease({name: "Chicken pox"}),
             scenarios: [mockScenario(), mockScenario()]
         };
@@ -18,4 +22,39 @@ describe("ScenarioGroup", () => {
         const rows = rendered.find("li");
         expect(rows).to.have.length(2);
     });
+
+    it("disables button and shows tooltip if canDownloadCoverage is false", () => {
+        const props: ScenarioGroupProps = {
+            touchstoneVersionId: "t1",
+            canDownloadCoverage: false,
+            disease: mockDisease({name: "Chicken pox"}),
+            scenarios: [mockScenario()]
+        };
+        const rendered = shallow(<ScenarioGroup {...props}/>);
+        expect(rendered.find("h3").text()).to.equal("Chicken pox");
+        const row = rendered.find("li").at(0);
+        const button = row.find(FileDownloadButton);
+
+        expect(button.prop("href")).to.be.null;
+        expect(row.find(UncontrolledTooltip)).to.have.lengthOf(1);
+
+    });
+
+    it("enables button and does not shows tooltip if canDownloadCoverage is true", () => {
+        const props: ScenarioGroupProps = {
+            touchstoneVersionId: "t1",
+            canDownloadCoverage: true,
+            disease: mockDisease({name: "Chicken pox"}),
+            scenarios: [mockScenario({id: "s1"})]
+        };
+        const rendered = shallow(<ScenarioGroup {...props}/>);
+        expect(rendered.find("h3").text()).to.equal("Chicken pox");
+        const row = rendered.find("li").at(0);
+        const button = row.find(FileDownloadButton);
+
+        expect(button.prop("href")).to.eq("/touchstones/t1/s1/coverage/csv/");
+        expect(row.find(UncontrolledTooltip)).to.have.lengthOf(0);
+
+    });
+
 });

--- a/app/src/test/admin/components/Touchstones/Scenarios/ScenariosListTests.tsx
+++ b/app/src/test/admin/components/Touchstones/Scenarios/ScenariosListTests.tsx
@@ -1,5 +1,5 @@
 import {createMockAdminStore} from "../../../../mocks/mockStore";
-import {mockDisease, mockScenario} from "../../../../mocks/mockModels";
+import {mockDisease, mockScenario, mockTouchstoneVersion} from "../../../../mocks/mockModels";
 import {shallow} from "enzyme";
 import {
     ScenariosList,
@@ -9,17 +9,42 @@ import {
 import * as React from "react";
 import {expect} from "chai";
 import {ScenarioGroup} from "../../../../../main/admin/components/Touchstones/Scenarios/ScenarioGroup";
+import {mockAdminState} from "../../../../mocks/mockStates";
 
 describe("ScenariosList", () => {
     it("maps state to props", () => {
         const scenarios = [mockScenario(), mockScenario()];
         const diseases = [mockDisease(), mockDisease()];
+        const touchstoneVersionId = "t1";
         const store = createMockAdminStore({
             scenario: {scenarios},
-            diseases: {diseases}
+            diseases: {diseases},
+            touchstones: {currentTouchstoneVersion: mockTouchstoneVersion({id: touchstoneVersionId})}
         });
         const rendered = shallow(<ScenariosList/>, {context: {store}});
-        const expectedProps: ScenariosListProps = {scenarios, diseases};
+        const expectedProps: ScenariosListProps = {
+            scenarios, diseases, touchstoneVersionId,
+            canDownloadCoverage: false
+        };
+        expect(rendered.find(ScenariosListComponent).props()).to.eql(expectedProps);
+    });
+
+    it("canDownloadCoverage is true when user has global coverage reading permission", () => {
+        const scenarios = [mockScenario(), mockScenario()];
+        const diseases = [mockDisease(), mockDisease()];
+        const touchstoneVersionId = "t1";
+
+        const store = createMockAdminStore({
+            scenario: {scenarios},
+            diseases: {diseases},
+            auth: {permissions: ["*/coverage.read"]},
+            touchstones: {currentTouchstoneVersion: mockTouchstoneVersion({id: touchstoneVersionId})}
+        });
+        const rendered = shallow(<ScenariosList/>, {context: {store}});
+        const expectedProps: ScenariosListProps = {
+            scenarios, diseases, touchstoneVersionId,
+            canDownloadCoverage: true
+        };
         expect(rendered.find(ScenariosListComponent).props()).to.eql(expectedProps);
     });
 
@@ -28,14 +53,18 @@ describe("ScenariosList", () => {
         const disease2 = mockDisease({id: "d2"});
         const d1scenarios = [mockScenario({disease: "d1"}), mockScenario({disease: "d1"})];
         const d2scenarios = [mockScenario({disease: "d2"})];
+        const touchstoneVersionId = "t1";
         const store = createMockAdminStore({
             scenario: {scenarios: d1scenarios.concat(d2scenarios)},
-            diseases: {diseases: [disease1, disease2]}
+            diseases: {diseases: [disease1, disease2]},
+            touchstones: {currentTouchstoneVersion: mockTouchstoneVersion({id: touchstoneVersionId})}
         });
         const rendered = shallow(<ScenariosList/>, {context: {store}}).dive();
         const groups = rendered.find(ScenarioGroup);
         expect(groups).to.have.length(2);
-        expect(groups.at(0).props()).to.eql({ disease: disease1, scenarios: d1scenarios });
-        expect(groups.at(1).props()).to.eql({ disease: disease2, scenarios: d2scenarios });
+        expect(groups.at(0).props()).to.eql({disease: disease1, scenarios: d1scenarios, touchstoneVersionId,
+            canDownloadCoverage: false});
+        expect(groups.at(1).props()).to.eql({disease: disease2, scenarios: d2scenarios, touchstoneVersionId,
+            canDownloadCoverage: false});
     });
 });

--- a/app/src/test/mocks/mockStore.ts
+++ b/app/src/test/mocks/mockStore.ts
@@ -2,12 +2,12 @@ import thunk from 'redux-thunk';
 import {AdminAppState} from "../../main/admin/reducers/adminAppReducers";
 import {ContribAppState} from "../../main/contrib/reducers/contribAppReducers";
 import {ReportAppState} from "../../main/report/reducers/reportAppReducers";
-import {RecursivePartial} from "./mockStates";
+import {mockAdminState, RecursivePartial} from "./mockStates";
 import {MockStore} from "redux-mock-store";
 const configureReduxMockStore  = require('redux-mock-store');
 
 export function createMockAdminStore(initialState?: RecursivePartial<AdminAppState>) {
-    return createMockStore(initialState);
+    return createMockStore(mockAdminState(initialState));
 }
 export function createMockContribStore(initialState?: RecursivePartial<ContribAppState>) {
     return createMockStore(initialState);


### PR DESCRIPTION
Show them as disabled with explanatory tooltip if user does not have global coverage reading permission.