### PR TITLE
I2136 - turn new templates on

### DIFF
--- a/app/src/main/contrib/components/Responsibilities/BurdenEstimates/UploadBurdenEstimatesContent.tsx
+++ b/app/src/main/contrib/components/Responsibilities/BurdenEstimates/UploadBurdenEstimatesContent.tsx
@@ -10,6 +10,7 @@ import {LoadingElement} from "../../../../shared/partials/LoadingElement/Loading
 import {ContribAppState} from "../../../reducers/contribAppReducers";
 import {isNullOrUndefined} from "util";
 import {settings} from "../../../../shared/Settings";
+import {InternalLink} from "../../../../shared/components/InternalLink";
 
 export interface UploadBurdenEstimatesContentProps {
     touchstone: TouchstoneVersion;
@@ -23,6 +24,8 @@ export interface UploadBurdenEstimatesContentProps {
 
 export class UploadBurdenEstimatesContentComponent extends React.Component<UploadBurdenEstimatesContentProps> {
     render() {
+        const newTemplatesUrl = `/${this.props.group.id}/responsibilities/${this.props.touchstone.id}/templates/`;
+
         return <div>
             <p>
                 On this page you can upload burden estimates for the following scenario. We expect estimates which
@@ -42,16 +45,19 @@ export class UploadBurdenEstimatesContentComponent extends React.Component<Uploa
                     <td>Scenario</td>
                     <td>{this.props.scenario.description}</td>
                 </tr>
-                {settings.showOldTemplates && <tr>
+                <tr>
                     <td>Burden estimates template</td>
                     <td>
+                        {settings.showOldTemplates &&
                         <TemplateLink
                             diseaseId={this.props.scenario.disease}
                             groupId={this.props.group.id}
                             touchstoneId={this.props.touchstone.id}
-                        />
+                        />}
+                        {settings.showNewTemplates &&
+                        <InternalLink href={newTemplatesUrl}>Download templates</InternalLink> }
                     </td>
-                </tr>}
+                </tr>
                 </tbody>
             </table>
 

--- a/app/src/main/contrib/components/Responsibilities/BurdenEstimates/UploadBurdenEstimatesContent.tsx
+++ b/app/src/main/contrib/components/Responsibilities/BurdenEstimates/UploadBurdenEstimatesContent.tsx
@@ -9,6 +9,7 @@ import {UploadBurdenEstimatesForm} from "./UploadBurdenEstimatesForm";
 import {LoadingElement} from "../../../../shared/partials/LoadingElement/LoadingElement";
 import {ContribAppState} from "../../../reducers/contribAppReducers";
 import {isNullOrUndefined} from "util";
+import {settings} from "../../../../shared/Settings";
 
 export interface UploadBurdenEstimatesContentProps {
     touchstone: TouchstoneVersion;
@@ -41,7 +42,7 @@ export class UploadBurdenEstimatesContentComponent extends React.Component<Uploa
                     <td>Scenario</td>
                     <td>{this.props.scenario.description}</td>
                 </tr>
-                <tr>
+                {settings.showOldTemplates && <tr>
                     <td>Burden estimates template</td>
                     <td>
                         <TemplateLink
@@ -50,7 +51,7 @@ export class UploadBurdenEstimatesContentComponent extends React.Component<Uploa
                             touchstoneId={this.props.touchstone.id}
                         />
                     </td>
-                </tr>
+                </tr>}
                 </tbody>
             </table>
 

--- a/app/src/main/shared/settings/docker.ts
+++ b/app/src/main/shared/settings/docker.ts
@@ -14,5 +14,6 @@ export const settings: Partial<Settings> = {
     report: {
         publicPath: "/reports",
         requiresModellingGroupMembership: false
-    }
+    },
+    showNewTemplates: true
 };

--- a/app/src/test/contrib/components/Responsibilities/BurdenEstimates/UploadBurdenEstimatesContentTests.tsx
+++ b/app/src/test/contrib/components/Responsibilities/BurdenEstimates/UploadBurdenEstimatesContentTests.tsx
@@ -32,6 +32,7 @@ import {
 } from "../../../../../main/contrib/components/Responsibilities/BurdenEstimates/UploadBurdenEstimatesForm";
 import {TemplateLink} from "../../../../../main/contrib/components/Responsibilities/Overview/List/OldStyleTemplates/TemplateLink";
 import {RecursivePartial} from "../../../../mocks/mockStates";
+import {settings} from "../../../../../main/shared/Settings";
 
 describe("UploadBurdenEstimatesContent", () => {
 
@@ -98,16 +99,18 @@ describe("UploadBurdenEstimatesContent", () => {
         expect(firstTable.find('tr').at(1).find('td').at(1).text(), testScenario.description);
     });
 
-    it("renders on component level, passes props to TemplateLink component", () => {
-        const rendered = shallow(<UploadBurdenEstimatesContent/>, {context: {store}}).dive().dive();
-        const firstTable = rendered.find('table.specialColumn').at(0);
-        const burdEstimatesTemplatesCell = firstTable.find('tr').at(2).find('td').at(1);
-        const burdenEstimatesTemplates = burdEstimatesTemplatesCell.find(TemplateLink);
-        const burdenEstimatesTemplatesProps = burdenEstimatesTemplates.props();
-        expect(burdenEstimatesTemplatesProps.diseaseId).to.eql(testDisease.id);
-        expect(burdenEstimatesTemplatesProps.groupId).to.eql(testGroup.id);
-        expect(burdenEstimatesTemplatesProps.touchstoneId).to.eql(testTouchstone.id);
-    });
+    if (settings.showOldTemplates) {
+        it("renders on component level, passes props to TemplateLink component", () => {
+            const rendered = shallow(<UploadBurdenEstimatesContent/>, {context: {store}}).dive().dive();
+            const firstTable = rendered.find('table.specialColumn').at(0);
+            const burdEstimatesTemplatesCell = firstTable.find('tr').at(2).find('td').at(1);
+            const burdenEstimatesTemplates = burdEstimatesTemplatesCell.find(TemplateLink);
+            const burdenEstimatesTemplatesProps = burdenEstimatesTemplates.props();
+            expect(burdenEstimatesTemplatesProps.diseaseId).to.eql(testDisease.id);
+            expect(burdenEstimatesTemplatesProps.groupId).to.eql(testGroup.id);
+            expect(burdenEstimatesTemplatesProps.touchstoneId).to.eql(testTouchstone.id);
+        });
+    }
 
     it("renders on component level, passes right params to CurrentEstimateSetSummary", () => {
         const rendered = shallow(<UploadBurdenEstimatesContent/>, {context: {store}}).dive().dive();

--- a/app/src/test/contrib/components/Responsibilities/BurdenEstimates/UploadBurdenEstimatesContentTests.tsx
+++ b/app/src/test/contrib/components/Responsibilities/BurdenEstimates/UploadBurdenEstimatesContentTests.tsx
@@ -33,6 +33,7 @@ import {
 import {TemplateLink} from "../../../../../main/contrib/components/Responsibilities/Overview/List/OldStyleTemplates/TemplateLink";
 import {RecursivePartial} from "../../../../mocks/mockStates";
 import {settings} from "../../../../../main/shared/Settings";
+import {InternalLink} from "../../../../../main/shared/components/InternalLink";
 
 describe("UploadBurdenEstimatesContent", () => {
 
@@ -109,6 +110,16 @@ describe("UploadBurdenEstimatesContent", () => {
             expect(burdenEstimatesTemplatesProps.diseaseId).to.eql(testDisease.id);
             expect(burdenEstimatesTemplatesProps.groupId).to.eql(testGroup.id);
             expect(burdenEstimatesTemplatesProps.touchstoneId).to.eql(testTouchstone.id);
+        });
+    }
+
+    if (settings.showNewTemplates) {
+        it("renders link to template download page", () => {
+            const rendered = shallow(<UploadBurdenEstimatesContent/>, {context: {store}}).dive().dive();
+            const firstTable = rendered.find('table.specialColumn').at(0);
+            const burdEstimatesTemplatesCell = firstTable.find('tr').at(2).find('td').at(1);
+            const link = burdEstimatesTemplatesCell.find(InternalLink);
+            expect(link.prop("href")).to.eql(`/${testGroup.id}/responsibilities/${testTouchstone.id}/templates/`);;
         });
     }
 


### PR DESCRIPTION
Also update the section on the burden estimate upload page with a link to the new templates page.

Note this PR turns new template links on, so once merged, a deploy will expose new templates to all users.