### PR TITLE
Added tooltips with guidance on file format

### DIFF
--- a/app/src/main/admin/components/Touchstones/Scenarios/ScenarioGroup.tsx
+++ b/app/src/main/admin/components/Touchstones/Scenarios/ScenarioGroup.tsx
@@ -45,14 +45,28 @@ const ScenarioItem = (props: ScenarioGroupProps, scenario: Scenario) => {
             <code className="col-4 text-center">{scenario.id}</code>
             <div className="col-4 text-right" id={`download-coverage-${scenario.id}`}>
                 Download coverage data in
-                <FileDownloadButton href={hrefLong}>
-                    Long format
-                </FileDownloadButton>
-                <FileDownloadButton href={hrefWide}>
-                    Wide format
-                </FileDownloadButton>
+                <span id={`download-long-format-${scenario.id}`}>
+                    <FileDownloadButton href={hrefLong}>
+                        Long format
+                    </FileDownloadButton>
+                </span>
+                <span id={`download-wide-format-${scenario.id}`}>
+                    <FileDownloadButton href={hrefWide} className={``}>
+                        Wide format
+                    </FileDownloadButton>
+                </span>
+                {props.canDownloadCoverage &&
+                <span>
+                    <UncontrolledTooltip  target={`download-long-format-${scenario.id}`} className={"text-muted download-format-tooltip"}>
+                        Long format includes a row for each year.
+                    </UncontrolledTooltip>
+                    <UncontrolledTooltip  target={`download-wide-format-${scenario.id}`} className={"text-muted download-format-tooltip"}>
+                        Wide format includes coverage and target values for all years in a single row.
+                    </UncontrolledTooltip>
+                </span>}
+
                 {!props.canDownloadCoverage &&
-                <UncontrolledTooltip placement="bottom" target={`download-coverage-${scenario.id}`}>
+                <UncontrolledTooltip placement="bottom" target={`download-coverage-${scenario.id}`} className={"download-permission-tooltip"} >
                     You do not have permission to download coverage
                 </UncontrolledTooltip>}
             </div>

--- a/app/src/main/admin/components/Touchstones/Scenarios/ScenariosList.tsx
+++ b/app/src/main/admin/components/Touchstones/Scenarios/ScenariosList.tsx
@@ -4,6 +4,7 @@ import * as React from "react";
 import {connect} from "react-redux";
 import {ScenarioGroup} from "./ScenarioGroup";
 import {discardDispatch} from "../../../../shared/Helpers";
+import {UncontrolledTooltip} from "reactstrap";
 
 export interface ScenariosListProps {
     scenarios: Scenario[];

--- a/app/src/main/contrib/components/Responsibilities/Coverage/DownloadCoverageContent.tsx
+++ b/app/src/main/contrib/components/Responsibilities/Coverage/DownloadCoverageContent.tsx
@@ -98,7 +98,16 @@ export class DownloadCoverageContentComponent extends React.Component<DownloadCo
             </div>
             <div className="row mt-4">
                 <div className="col-12 col-md-6">
-                    <div className="smallTitle">Choose format</div>
+                    <div>
+                        <span className="smallTitle">
+                            Choose format
+                        </span>
+                        <a href={"#"} id={"format-tooltip"} className={"ml-1 small"} onClick={(e)=> {e.preventDefault()}}>What's this?</a>
+                        <UncontrolledTooltip target="format-tooltip" className={"text-muted"}>
+                            Wide format includes coverage and target values for all years in a single row. Long format
+                            includes a row for each year.
+                        </UncontrolledTooltip>
+                    </div>
                     <table className="options">
                         <tbody>
                         <tr className="specialColumn">

--- a/app/src/main/shared/components/Demographics/DemographicOptions.tsx
+++ b/app/src/main/shared/components/Demographics/DemographicOptions.tsx
@@ -10,6 +10,7 @@ import {ContribAppState} from "../../../contrib/reducers/contribAppReducers";
 import {AdminAppState} from "../../../admin/reducers/adminAppReducers";
 import {demographicActionCreators} from "../../actions/demographicActionCreators";
 import {LoadingElement} from "../../partials/LoadingElement/LoadingElement";
+import {UncontrolledTooltip} from "reactstrap";
 
 export interface DemographicOptionsProps {
     dataSets: DemographicDataset[];
@@ -70,6 +71,11 @@ export class DemographicOptionsComponent extends React.Component<DemographicOpti
                     <label className="col-form-label">
                         Format
                     </label>
+                    <a href={"#"} id={"format-tooltip"} className={"ml-1 small"} onClick={(e)=> {e.preventDefault()}}>What's this?</a>
+                    <UncontrolledTooltip target="format-tooltip" className={"text-muted"}>
+                        Wide format includes values for all years in a single row. Long format
+                        includes a row for each year.
+                    </UncontrolledTooltip>
                 </td>
                 <td><FormatControl
                     value={props.selectedFormat}

--- a/app/src/test/admin/components/Touchstones/Scenarios/ScenarioGroupTests.tsx
+++ b/app/src/test/admin/components/Touchstones/Scenarios/ScenarioGroupTests.tsx
@@ -23,7 +23,7 @@ describe("ScenarioGroup", () => {
         expect(rows).to.have.length(2);
     });
 
-    it("disables button and shows tooltip if canDownloadCoverage is false", () => {
+    it("disables button and shows permission tooltip if canDownloadCoverage is false", () => {
         const props: ScenarioGroupProps = {
             touchstoneVersionId: "t1",
             canDownloadCoverage: false,
@@ -41,11 +41,27 @@ describe("ScenarioGroup", () => {
             { expect(button.prop("href")).to.be.null; }
         );
 
-        expect(row.find(UncontrolledTooltip)).to.have.lengthOf(1);
+        expect(row.find('.download-permission-tooltip')).to.have.lengthOf(1)
 
     });
 
-    it("enables button and does not shows tooltip if canDownloadCoverage is true", () => {
+
+    it("does not show format tooltips if canDownloadCoverage is false", () => {
+        const props: ScenarioGroupProps = {
+            touchstoneVersionId: "t1",
+            canDownloadCoverage: false,
+            disease: mockDisease({name: "Chicken pox"}),
+            scenarios: [mockScenario()]
+        };
+        const rendered = shallow(<ScenarioGroupComponent {...props}/>);
+        expect(rendered.find("h3").text()).to.equal("Chicken pox");
+        const row = rendered.find("li").at(0);
+
+        expect(row.find('.download-format-tooltip')).to.have.lengthOf(0);
+
+    });
+
+    it("enables button and does not show permission tooltip if canDownloadCoverage is true", () => {
         const props: ScenarioGroupProps = {
             touchstoneVersionId: "t1",
             canDownloadCoverage: true,
@@ -59,7 +75,21 @@ describe("ScenarioGroup", () => {
 
         expect(buttons.at(0).prop("href")).to.eq("/touchstones/t1/s1/coverage/csv/?format=long");
         expect(buttons.at(1).prop("href")).to.eq("/touchstones/t1/s1/coverage/csv/?format=wide");
-        expect(row.find(UncontrolledTooltip)).to.have.lengthOf(0);
+        expect(row.find('.download-permission-tooltip')).to.have.lengthOf(0);
+
+    });
+
+    it("shows format tooltips if canDownloadCoverage is true", () => {
+        const props: ScenarioGroupProps = {
+            touchstoneVersionId: "t1",
+            canDownloadCoverage: true,
+            disease: mockDisease({name: "Chicken pox"}),
+            scenarios: [mockScenario({id: "s1"})]
+        };
+        const rendered = shallow(<ScenarioGroupComponent {...props}/>);
+        expect(rendered.find("h3").text()).to.equal("Chicken pox");
+        const row = rendered.find("li").at(0);
+        expect(row.find('.download-format-tooltip')).to.have.lengthOf(2);
 
     });
 

--- a/app/src/test/contrib/components/Responsibilities/Coverage/DownloadCoverageContentTests.tsx
+++ b/app/src/test/contrib/components/Responsibilities/Coverage/DownloadCoverageContentTests.tsx
@@ -26,6 +26,7 @@ import {coverageActionCreators} from "../../../../../main/contrib/actions/covera
 import {ConfidentialityAgreementComponent} from "../../../../../main/contrib/components/Responsibilities/Overview/ConfidentialityAgreement";
 import {userActionCreators} from "../../../../../main/contrib/actions/userActionCreators";
 import {FileDownloadButton} from "../../../../../main/shared/components/FileDownloadLink";
+import {UncontrolledTooltip} from "reactstrap";
 
 describe("Download Coverage Content Component", () => {
 
@@ -112,6 +113,15 @@ describe("Download Coverage Content Component", () => {
         expect(rendered.find(CoverageSetList).props().coverageSets).to.eql([testCoverageSet]);
         expect(rendered.find(FormatControl).length).to.equal(1);
         expect(rendered.find(FormatControl).props().value).to.eql(testState.coverage.selectedFormat);
+    });
+
+    it("renders tooltips", () => {
+        const rendered = shallow(<DownloadCoverageContent/>, {context: {store}}).dive().dive().dive()
+            .dive().dive().dive();
+        const tooltips = rendered.find(UncontrolledTooltip);
+        expect(tooltips.length).to.eql(2);
+        expect(tooltips.first().props().target).to.eql("format-tooltip");
+        expect(tooltips.at(1).props().target).to.eql("countries-tooltip");
     });
 
     it("can trigger mapped chose format", () => {

--- a/app/src/test/shared/components/Demographics/DemographicOptionsTests.tsx
+++ b/app/src/test/shared/components/Demographics/DemographicOptionsTests.tsx
@@ -17,6 +17,7 @@ import {demographicActionCreators} from "../../../../main/shared/actions/demogra
 import {GenderControl} from "../../../../main/shared/components/Demographics/GenderControl";
 import {RadioButtonGroupProperties} from "react-radio-button-group";
 import {FormatControl} from "../../../../main/shared/components/FormatControl";
+import {UncontrolledTooltip} from "reactstrap";
 
 describe("DemographicOptions", () => {
 
@@ -138,6 +139,12 @@ describe("DemographicOptions", () => {
             { value: 'long', label: 'Long' },
             { value: 'wide', label: 'Wide' }
         ]);
+    });
+
+    it("renders on component level, renders format tooltip", () => {
+        const rendered = shallow(<DemographicOptions/>, {context: {store}}).dive().dive();
+        const tooltip = rendered.find(UncontrolledTooltip);
+        expect(tooltip.props().target).to.equal("format-tooltip");
     });
 
     it("renders on component level, on format selection, triggers actions", () => {


### PR DESCRIPTION
Not sure if putting the format guidance in tooltips is the right thing (but is consistent with countries guidance in the case of coverage data). Maybe don't need it at all in Admin any more? (Tooltips on the buttons might get a bit annoying?)