### PR TITLE
Removing id from changelog link

### DIFF
--- a/app/src/main/report/components/Sidebar/Sidebar.tsx
+++ b/app/src/main/report/components/Sidebar/Sidebar.tsx
@@ -57,7 +57,7 @@ export const SidebarComponent: React.StatelessComponent<SidebarProps> = (props: 
                              active={props.active == ReportTabEnum.DOWNLOAD}>Downloads</NavLink>
                 </NavItem>
                 <NavItem>
-                    <NavLink href="#changelog" id={"changelog"}>Changelog</NavLink>
+                    <NavLink href="#changelog">Changelog</NavLink>
                 </NavItem>
             </ul>
             <hr/>


### PR DESCRIPTION
The changelog link had somehow re-acquired its id (previously used as a target for the 'coming soon' tooltip), so the anchor was acting like an anchor!