### PR TITLE
i2772: Use the smaller container

### DIFF
--- a/app/docker-compose.yml
+++ b/app/docker-compose.yml
@@ -24,7 +24,7 @@ services:
     image: docker.montagu.dide.ic.ac.uk:5000/montagu-db:${MONTAGU_DB_VERSION}
     command: /etc/montagu/postgresql.test.conf
   orderly:
-    image: docker.montagu.dide.ic.ac.uk:5000/montagu-orderly:${MONTAGU_ORDERLY_VERSION}
+    image: docker.montagu.dide.ic.ac.uk:5000/orderly.server:${MONTAGU_ORDERLY_VERSION}
     volumes:
     - orderly_volume:/orderly
     command: --port 8321 --go-signal /orderly_go /orderly


### PR DESCRIPTION
As discussed yesterday, the webapps should use orderly.server not montagu-orderly for testing

The image is much smaller and built more often