### PR TITLE
VIMC-2796 move success and error alerts to top level component

### DIFF
--- a/app/src/main/contrib/components/Responsibilities/BurdenEstimates/PopulateBurdenEstimatesForm.tsx
+++ b/app/src/main/contrib/components/Responsibilities/BurdenEstimates/PopulateBurdenEstimatesForm.tsx
@@ -190,13 +190,6 @@ export class PopulateEstimatesFormComponent extends React.Component<PopulateEsti
                        toggle={() => this.resetUploadState(false)}>
                     {this.state.uploadErrors.length > 0 && this.state.uploadErrors[0].message}
                 </Alert>
-                <Alert color="danger" id={"populate-errors"} isOpen={this.props.populateErrors.length > 0}
-                       toggle={this.props.resetPopulateState}>
-                    {this.props.populateErrors.length > 0 && this.props.populateErrors[0].message}
-                </Alert>
-                <Alert color="success" isOpen={this.props.hasPopulateSuccess} toggle={this.props.resetPopulateState}>
-                    Success! You have uploaded a new burden estimate set
-                </Alert>
                 <button disabled={this.uploadDisabled()}
                         className="submit start"
                         onClick={this.startUpload}>Upload

--- a/app/src/main/report/components/ReportsList/ReportListTable.tsx
+++ b/app/src/main/report/components/ReportsList/ReportListTable.tsx
@@ -182,7 +182,7 @@ export class ReportsListTable extends React.Component<ReportsListTableProps, any
             </ButtonGroup>
             <ReactTable
                 pivotBy={["name"]}
-                defaultSorted={[{id: "version", desc: false}]}
+                defaultSorted={[{id: "version", desc: true}]}
                 defaultFilterMethod={(filter: Filter, row: ReportRow) =>
                     String(row[filter.id]).toLowerCase().indexOf(filter.value.toLowerCase()) > -1}
                 filterable

--- a/app/src/test/contrib/components/Responsibilities/BurdenEstimates/PopulateBurdenEstimateFormComponentTests.tsx
+++ b/app/src/test/contrib/components/Responsibilities/BurdenEstimates/PopulateBurdenEstimateFormComponentTests.tsx
@@ -213,15 +213,6 @@ describe("Populate Burden Estimates Form Component tests", () => {
         expect(newState.file.fileName).to.eq("test.csv")
     });
 
-    it("shows success message on file population success", () => {
-
-        const result = getComponent({hasPopulateSuccess: true});
-        fakeUploadClient.emit("fileSuccess");
-
-        const successAlert = result.find(Alert).filterWhere((alert) => alert.props().color == "success");
-        expect(successAlert.props().isOpen).to.be.true;
-    });
-
     it("populates estimates on file upload success", () => {
 
         const populateEstimateSet = sandbox.sinon.stub();

--- a/app/src/test/contrib/components/Responsibilities/BurdenEstimates/UploadBurdenEstimatesContentTests.tsx
+++ b/app/src/test/contrib/components/Responsibilities/BurdenEstimates/UploadBurdenEstimatesContentTests.tsx
@@ -159,7 +159,8 @@ describe("UploadBurdenEstimatesContent", () => {
         const rendered = shallow(<UploadBurdenEstimatesContent/>, {context: {store}}).dive().dive();
         const uploadBurdenEstimatesForm = rendered.find(UploadBurdenEstimatesForm);
         expect(uploadBurdenEstimatesForm.length).to.equal(1);
-        const expected: UploadBurdenEstimatesFormComponentProps = {
+
+        const expected: Partial<UploadBurdenEstimatesFormComponentProps> = {
             canCreate: true,
             canUpload: false,
             estimateSet: testEstimateSet,


### PR DESCRIPTION
As I was testing on UAT it came to my attention that bc of the weird 2 step form the error/success alerts after uploading a set of estimates were in the wrong place. 

They should live one component level up from the `PopulateBurdenEstimatesForm`, in the component that renders both that and the `CreateBurdenEstimateSetForm`. This component was still expecting error/success messages to come from a query string, so have changed it over to look in the store state instead.