### PR TITLE
Upgrade webpack and fix dependencies

### DIFF
--- a/app/docker/shared-build-env.dockerfile
+++ b/app/docker/shared-build-env.dockerfile
@@ -28,7 +28,7 @@ RUN curl -L https://github.com/docker/compose/releases/download/1.16.1/docker-co
 RUN chmod 744 /usr/local/bin/docker-compose
 
 # Install webpack
-RUN npm install webpack@v3.10.0 --global
+RUN npm install webpack@v4.30.0 --global
 
 # Create workspace
 WORKDIR /workspace

--- a/app/docker/shared-build-env.dockerfile
+++ b/app/docker/shared-build-env.dockerfile
@@ -28,7 +28,7 @@ RUN curl -L https://github.com/docker/compose/releases/download/1.16.1/docker-co
 RUN chmod 744 /usr/local/bin/docker-compose
 
 # Install webpack
-RUN npm install webpack@v4.30.0 --global
+RUN npm install webpack@v4.30.0 webpack-cli --global
 
 # Create workspace
 WORKDIR /workspace

--- a/app/docker/shared-build-env.dockerfile
+++ b/app/docker/shared-build-env.dockerfile
@@ -46,6 +46,7 @@ RUN ./src/webmodels/gradlew
 
 # Install Node dependencies
 COPY package.json .
+COPY package-lock.json .
 RUN npm install --quiet 2>&1
 
 # Generate Typescript models from montagu-webmodels


### PR DESCRIPTION
Some package update is breaking everything, possibly because of a memory leak:
http://teamcity.montagu.dide.ic.ac.uk:8111/viewLog.html?buildId=43316&buildTypeId=montagu_webapps_build_contrib

Seeing as we are actually using a package-lock file, I've just changed the build environment to install dependencies from there to pin the versions. I will try to work out which package broke things and whether it's a bug or whether we really should increase the memory allocated to node, but for now lets just pin dependencies.

Upgraded webpack while I was at it.