### PR TITLE
Vimc 2911 Bugfix: success message persists after navigating away from burden estimate upload page 

### DIFF
--- a/app/src/main/contrib/actions/pages/uploadBurdenEstimatesPageActionCreators.ts
+++ b/app/src/main/contrib/actions/pages/uploadBurdenEstimatesPageActionCreators.ts
@@ -6,6 +6,7 @@ import {responsibilitiesActionCreators} from "../responsibilitiesActionCreators"
 import {ContribAppState} from "../../reducers/contribAppReducers";
 import {ContribPageActionCreators} from "./ContribPageActionCreators";
 import {PageBreadcrumb} from "../../../shared/components/PageWithHeader/PageProperties";
+import {estimatesActionCreators} from "../estimatesActionCreators";
 
 class UploadBurdenEstimatesPageActionCreators extends ContribPageActionCreators<UploadBurdenEstimatesPageLocationProps> {
     parent = responsibilityOverviewPageActionCreators;
@@ -20,6 +21,7 @@ class UploadBurdenEstimatesPageActionCreators extends ContribPageActionCreators<
     loadData(params: UploadBurdenEstimatesPageLocationProps) {
         return async (dispatch: Dispatch<ContribAppState>) => {
             dispatch(responsibilitiesActionCreators.setCurrentResponsibility(params.scenarioId));
+            dispatch(estimatesActionCreators.resetPopulateState());
         }
     }
 }

--- a/app/src/test/contrib/actions/pages/UploadBurdenEstimatesPageActionsTests.ts
+++ b/app/src/test/contrib/actions/pages/UploadBurdenEstimatesPageActionsTests.ts
@@ -7,6 +7,7 @@ import {uploadBurdenEstimatesPageActionCreators} from "../../../../main/contrib/
 import {responsibilitiesActionCreators} from "../../../../main/contrib/actions/responsibilitiesActionCreators";
 import {responsibilityOverviewPageActionCreators} from "../../../../main/contrib/actions/pages/responsibilityOverviewPageActionCreators";
 import {mockContribState} from "../../../mocks/mockStates";
+import {estimatesActionCreators} from "../../../../main/contrib/actions/estimatesActionCreators";
 
 describe("Upload burden estimates page actions tests", () => {
     const sandbox = new Sandbox();
@@ -35,11 +36,14 @@ describe("Upload burden estimates page actions tests", () => {
         expect(result.urlFragment).to.eq("burdens/s1/");
     });
 
-    it("sets current responsibility set", async () => {
+    it("sets current responsibility set and resets estimate populate state", async () => {
         const store = createMockContribStore();
 
         sandbox.stubReduxActionCreator(responsibilitiesActionCreators, "setCurrentResponsibility",
             {type: "test-responsibility-type"});
+
+        sandbox.stubReduxActionCreator(estimatesActionCreators, "resetPopulateState",
+            {type: "test-reset-estimate"})
 
         await store.dispatch(uploadBurdenEstimatesPageActionCreators
             .loadData({groupId: "g1", touchstoneId: "t1", scenarioId: "s1"}));
@@ -48,7 +52,9 @@ describe("Upload burden estimates page actions tests", () => {
 
         const expectedPayload = [
             {type: "test-responsibility-type", props: "s1"},
+            {type: "test-reset-estimate", props: ""}
         ];
         expect(actions).to.eql(expectedPayload);
+
     });
 });

--- a/app/src/test/contrib/actions/pages/UploadBurdenEstimatesPageActionsTests.ts
+++ b/app/src/test/contrib/actions/pages/UploadBurdenEstimatesPageActionsTests.ts
@@ -52,7 +52,7 @@ describe("Upload burden estimates page actions tests", () => {
 
         const expectedPayload = [
             {type: "test-responsibility-type", props: "s1"},
-            {type: "test-reset-estimate", props: ""}
+            {type: "test-reset-estimate", props: undefined}
         ];
         expect(actions).to.eql(expectedPayload);
 


### PR DESCRIPTION
This should fix this bug, but see related issue https://vimc.myjetbrains.com/youtrack/issue/VIMC-2978

UPDATE: can't seem to reproduce this other bug at all now!