### PR TITLE
model meta table with the basic model info that we have

### DIFF
--- a/app/src/integrationTests/AdminIntegrationTests.tsx
+++ b/app/src/integrationTests/AdminIntegrationTests.tsx
@@ -60,6 +60,15 @@ class AdminIntegrationTests extends IntegrationTestSuite {
             ]);
         });
 
+        it("can fetch models", async () => {
+            await addGroups(this.db);
+            const result = await (new ModellingGroupsService(this.store.dispatch, this.store.getState)).getAllModels();
+            expect(result).to.eql([
+                {citation: "Citation", description: "A model", id: "model", modelling_group: "g1"},
+                {citation: "Citation", description: "Another model", id: "model2", modelling_group: "g2"}
+            ]);
+        });
+
         it("can fetch group details", async () => {
             await addGroups(this.db);
             const result = await (new ModellingGroupsService(this.store.dispatch, this.store.getState)).getGroupDetails('g1');
@@ -281,6 +290,7 @@ function addGroups(db: Client): Promise<QueryResult> {
             INSERT INTO modelling_group (id, description, institution, pi) VALUES ('g2', 'Group 2', '', '');
             
             INSERT INTO model (id, modelling_group, description, citation, is_current) VALUES ('model', 'g1', 'A model', 'Citation', true);
+            INSERT INTO model (id, modelling_group, description, citation, is_current) VALUES ('model2', 'g2', 'Another model', 'Citation', true);
             
             INSERT INTO app_user (username) VALUES ('bob'); 
             INSERT INTO user_group (id, name) VALUES ('bob', 'bob');

--- a/app/src/main/admin/actionTypes/ModellingGroupsTypes.ts
+++ b/app/src/main/admin/actionTypes/ModellingGroupsTypes.ts
@@ -1,4 +1,4 @@
-import {ModellingGroup, ModellingGroupDetails, User} from "../../shared/models/Generated";
+import {ModellingGroup, ModellingGroupDetails, ResearchModel, User} from "../../shared/models/Generated";
 
 export enum ModellingGroupTypes {
     GROUPS_FETCHED = "GROUPS_FETCHED",
@@ -6,7 +6,8 @@ export enum ModellingGroupTypes {
     SET_CURRENT_GROUP = "SET_CURRENT_GROUP",
     SET_CURRENT_GROUP_MEMBERS = "SET_CURRENT_GROUP_MEMBERS",
     ADD_MODELLING_GROUP = "ADD_MODELLING_GROUP",
-    SET_SHOW_CREATE_GROUP = "SET_SHOW_CREATE_GROUP"
+    SET_SHOW_CREATE_GROUP = "SET_SHOW_CREATE_GROUP",
+    MODELS_FETCHED = "MODELS_FETCHED",
 }
 
 export interface SetShowCreateGroup {
@@ -17,6 +18,11 @@ export interface SetShowCreateGroup {
 export interface GroupsFetched {
     type: ModellingGroupTypes.GROUPS_FETCHED;
     data: ModellingGroup[];
+}
+
+export interface ModelsFetched {
+    type: ModellingGroupTypes.MODELS_FETCHED;
+    data: ResearchModel[];
 }
 
 export interface SetCurrentGroup {
@@ -46,4 +52,4 @@ export type ModellingGroupsAction =
     | SetCurrentGroupMembers
     | AddModellingGroup
     | SetShowCreateGroup
-    ;
+    | ModelsFetched;

--- a/app/src/main/admin/actions/modellingGroupsActionCreators.ts
+++ b/app/src/main/admin/actions/modellingGroupsActionCreators.ts
@@ -122,6 +122,17 @@ export const modellingGroupsActionCreators = {
             type: ModellingGroupTypes.SET_SHOW_CREATE_GROUP,
             data: show
         }
+    },
+
+    getAllModels() {
+        return async (dispatch: Dispatch<AdminAppState>, getState: () => AdminAppState) => {
+            const models = await (new ModellingGroupsService(dispatch, getState)).getAllModels();
+            dispatch({
+                type: ModellingGroupTypes.MODELS_FETCHED,
+                data: models
+            })
+
+        }
     }
 
 };

--- a/app/src/main/admin/actions/pages/ModelMetaPageActionCreators.ts
+++ b/app/src/main/admin/actions/pages/ModelMetaPageActionCreators.ts
@@ -1,5 +1,4 @@
 import {AdminPageActionCreators} from "./AdminPageActionCreators";
-import {TouchstoneVersionPageLocationProps} from "../../components/Touchstones/SingleTouchstoneVersion/TouchstoneVersionPage";
 import {modellingGroupsListPageActionCreators} from "./ModellingGroupsListPageActionCreators";
 import {AdminAppState} from "../../reducers/adminAppReducers";
 import {PageBreadcrumb} from "../../../shared/components/PageWithHeader/PageProperties";
@@ -23,7 +22,7 @@ class ModelMetaPageActionCreators extends AdminPageActionCreators<{}> {
 
     loadData() {
         return async (dispatch: Dispatch<AdminAppState>) => {
-            await dispatch(modellingGroupsActionCreators.getAllGroups());
+            await dispatch(modellingGroupsActionCreators.getAllModels());
         }
     }
 }

--- a/app/src/main/admin/actions/pages/ModelMetaPageActionCreators.ts
+++ b/app/src/main/admin/actions/pages/ModelMetaPageActionCreators.ts
@@ -1,0 +1,31 @@
+import {AdminPageActionCreators} from "./AdminPageActionCreators";
+import {TouchstoneVersionPageLocationProps} from "../../components/Touchstones/SingleTouchstoneVersion/TouchstoneVersionPage";
+import {modellingGroupsListPageActionCreators} from "./ModellingGroupsListPageActionCreators";
+import {AdminAppState} from "../../reducers/adminAppReducers";
+import {PageBreadcrumb} from "../../../shared/components/PageWithHeader/PageProperties";
+import {Dispatch} from "redux";
+import {modellingGroupsActionCreators} from "../modellingGroupsActionCreators";
+
+class ModelMetaPageActionCreators extends AdminPageActionCreators<{}> {
+
+    parent = modellingGroupsListPageActionCreators;
+
+    title(): string {
+        return "Model Metadata"
+    }
+
+    createBreadcrumb(state: AdminAppState): PageBreadcrumb {
+        return {
+            name: this.title(),
+            urlFragment: "models/"
+        }
+    }
+
+    loadData() {
+        return async (dispatch: Dispatch<AdminAppState>) => {
+            await dispatch(modellingGroupsActionCreators.getAllGroups());
+        }
+    }
+}
+
+export const modelMetaPageActionCreators = new ModelMetaPageActionCreators();

--- a/app/src/main/admin/components/AdminRouter.tsx
+++ b/app/src/main/admin/components/AdminRouter.tsx
@@ -19,6 +19,7 @@ import {TouchstoneVersionPage} from "./Touchstones/SingleTouchstoneVersion/Touch
 import {DownloadDemographicsAdminPage} from "./Touchstones/Demography/DownloadDemographicsPage";
 import {ScenarioPage} from "./Touchstones/Scenarios/ScenarioPage";
 import {LoginPage} from "../../shared/components/LoginPage";
+import {ModelMetaPage} from "./ModellingGroups/Models/ModelMetaPage";
 
 interface AdminRouterProps {
     loggedIn: boolean;
@@ -30,6 +31,7 @@ export const AdminRouter: React.FunctionComponent<AdminRouterProps> = (props: Ad
     const loggedIn = <Switch>
         <Route exact path="/" component={MainMenuPage}/>
         <Route exact path="/modelling-groups/" component={ModellingGroupsListPage}/>
+        <Route exact path="/modelling-groups/models/" component={ModelMetaPage}/>
         <Route exact path="/modelling-groups/:groupId/" component={ModellingGroupDetailsPage}/>
         <Route exact path="/modelling-groups/:groupId/admin/" component={ModellingGroupMembersPage}/>
         <Route exact path="/touchstones/" component={TouchstoneListPage}/>

--- a/app/src/main/admin/components/ModellingGroups/Models/ModelMetaPage.tsx
+++ b/app/src/main/admin/components/ModellingGroups/Models/ModelMetaPage.tsx
@@ -1,0 +1,17 @@
+import {PageProperties} from "../../../../shared/components/PageWithHeader/PageProperties";
+import * as React from "react";
+import {PageArticle} from "../../../../shared/components/PageWithHeader/PageArticle";
+import {AdminPage} from "../../../AdminPage";
+import {modelMetaPageActionCreators} from "../../../actions/pages/ModelMetaPageActionCreators";
+import {ModelMetaTable} from "./ModelMetaTable";
+
+export class ModelMetaPageComponent extends React.Component<PageProperties<undefined>> {
+
+    render(): JSX.Element {
+        return <PageArticle title={this.props.title}>
+            <ModelMetaTable/>
+        </PageArticle>;
+    }
+}
+
+export const ModelMetaPage = AdminPage(modelMetaPageActionCreators)(ModelMetaPageComponent);

--- a/app/src/main/admin/components/ModellingGroups/Models/ModelMetaTable.tsx
+++ b/app/src/main/admin/components/ModellingGroups/Models/ModelMetaTable.tsx
@@ -1,0 +1,79 @@
+import * as React from "react";
+import {ResearchModel} from "../../../../shared/models/Generated";
+import {AdminAppState} from "../../../reducers/adminAppReducers";
+import {connect} from "react-redux";
+import {Res} from "awesome-typescript-loader/dist/checker/protocol";
+import {ILookup} from "../../../../shared/models/Lookup";
+
+interface ModelMetaProps {
+    models: ResearchModel[]
+}
+
+interface State {
+    data: ResearchModel[]
+    cols: ILookup<boolean>
+}
+
+class Model implements ResearchModel {
+    citation: string | null;
+    description: string;
+    id: string;
+    modelling_group: string;
+}
+
+export class ModelMetaTableComponent extends React.Component<ModelMetaProps, State> {
+
+    constructor(props: ModelMetaProps) {
+        super(props);
+
+        this.state = {data: props.models, cols: {}};
+        this.onSort = this.onSort.bind(this)
+    }
+
+    onSort(sortKey: keyof ResearchModel) {
+        this.state.cols[sortKey] = !this.state.cols[sortKey];
+
+        const ascending = this.state.cols[sortKey] ? 1 : -1;
+        const data = this.state.data;
+        data.sort((a, b) => ascending * a[sortKey].localeCompare(b[sortKey]));
+        this.setState({data});
+    }
+
+    render() {
+        return <table>
+            <thead>
+            <tr>
+                <th onClick={() => this.onSort('modelling_group')}>Group</th>
+                <th onClick={() => this.onSort('id')}>Model Name</th>
+                {/*<th onClick={() => this.onSort('disease')}>Disease</th>*/}
+                {/*<th onClick={() => this.onSort('type')}>Model Type</th>*/}
+                {/*<th onClick={() => this.onSort('code')}>Code</th>*/}
+                {/*<th>Max Countries</th>*/}
+                {/*<th>Years</th>*/}
+                {/*<th>Ages</th>*/}
+                {/*<th>Cohorts</th>*/}
+                {/*<th>Outcomes</th>*/}
+                {/*<th>DALYs</th>*/}
+            </tr>
+            </thead>
+            <tbody>
+            {this.state.data.map(function (model: ResearchModel, index: number) {
+                return (
+                    <tr key={index} data-item={model}>
+                        <td data-title="group">{model.modelling_group}</td>
+                        <td data-title="name">{model.id}</td>
+                    </tr>
+                );
+            })}
+            </tbody>
+        </table>
+    }
+}
+
+export const mapStateToProps = (state: AdminAppState): ModelMetaProps => {
+    return {
+        models: state.groups.models
+    }
+};
+
+export const ModelMetaTable = connect(mapStateToProps)(ModelMetaTableComponent);

--- a/app/src/main/admin/components/ModellingGroups/Models/ModelMetaTable.tsx
+++ b/app/src/main/admin/components/ModellingGroups/Models/ModelMetaTable.tsx
@@ -31,7 +31,7 @@ export class ModelMetaTableComponent extends React.Component<ModelMetaProps, Sta
 
     onSort(sortKey: keyof ResearchModel) {
 
-        const cols: ILookup<boolean> = {};
+        const cols: ILookup<boolean> = {...this.state.cols};
         cols[sortKey] = !this.state.cols[sortKey];
 
         const ascending = cols[sortKey] ? 1 : -1;
@@ -41,14 +41,28 @@ export class ModelMetaTableComponent extends React.Component<ModelMetaProps, Sta
         });
     }
 
+    calculateClass(id: string) {
+        if (this.state.cols[id] === true) {
+            return "asc"
+        }
+        if (this.state.cols[id] === false){
+            return "desc"
+        }
+        return ""
+    }
+
     render() {
+
+
         return <div>
             <p>Click on a column header to sort</p>
             <table>
                 <thead>
                 <tr>
-                    <th className="sortable" onClick={() => this.onSort('modelling_group')}>Group</th>
-                    <th className="sortable" onClick={() => this.onSort('id')}>Model Name</th>
+                    <th className={"sortable " + this.calculateClass("modelling_group")}
+                        onClick={() => this.onSort('modelling_group')}>Group</th>
+                    <th className={"sortable " + this.calculateClass("id")}
+                        onClick={() => this.onSort('id')}>Model Name</th>
                     {/*<th onClick={() => this.onSort('disease')}>Disease</th>*/}
                     {/*<th onClick={() => this.onSort('type')}>Model Type</th>*/}
                     {/*<th onClick={() => this.onSort('code')}>Code</th>*/}

--- a/app/src/main/admin/components/ModellingGroups/Models/ModelMetaTable.tsx
+++ b/app/src/main/admin/components/ModellingGroups/Models/ModelMetaTable.tsx
@@ -2,7 +2,6 @@ import * as React from "react";
 import {ResearchModel} from "../../../../shared/models/Generated";
 import {AdminAppState} from "../../../reducers/adminAppReducers";
 import {connect} from "react-redux";
-import {Res} from "awesome-typescript-loader/dist/checker/protocol";
 import {ILookup} from "../../../../shared/models/Lookup";
 
 interface ModelMetaProps {
@@ -10,15 +9,8 @@ interface ModelMetaProps {
 }
 
 interface State {
-    data: ResearchModel[]
     cols: ILookup<boolean>
-}
-
-class Model implements ResearchModel {
-    citation: string | null;
-    description: string;
-    id: string;
-    modelling_group: string;
+    data: ResearchModel[]
 }
 
 export class ModelMetaTableComponent extends React.Component<ModelMetaProps, State> {
@@ -26,47 +18,61 @@ export class ModelMetaTableComponent extends React.Component<ModelMetaProps, Sta
     constructor(props: ModelMetaProps) {
         super(props);
 
-        this.state = {data: props.models, cols: {}};
+        this.state = {cols: {}, data: []};
         this.onSort = this.onSort.bind(this)
     }
 
-    onSort(sortKey: keyof ResearchModel) {
-        this.state.cols[sortKey] = !this.state.cols[sortKey];
+    static getDerivedStateFromProps(props: ModelMetaProps, state: State) {
+        return {
+            cols: state.cols,
+            data: props.models
+        };
+    }
 
-        const ascending = this.state.cols[sortKey] ? 1 : -1;
-        const data = this.state.data;
-        data.sort((a, b) => ascending * a[sortKey].localeCompare(b[sortKey]));
-        this.setState({data});
+    onSort(sortKey: keyof ResearchModel) {
+
+        const cols: ILookup<boolean> = {};
+        cols[sortKey] = !this.state.cols[sortKey];
+
+        const ascending = cols[sortKey] ? 1 : -1;
+        this.setState({
+            cols: {...cols},
+            data: this.state.data.sort((a, b) => ascending * a[sortKey].localeCompare(b[sortKey]))
+        });
     }
 
     render() {
-        return <table>
-            <thead>
-            <tr>
-                <th onClick={() => this.onSort('modelling_group')}>Group</th>
-                <th onClick={() => this.onSort('id')}>Model Name</th>
-                {/*<th onClick={() => this.onSort('disease')}>Disease</th>*/}
-                {/*<th onClick={() => this.onSort('type')}>Model Type</th>*/}
-                {/*<th onClick={() => this.onSort('code')}>Code</th>*/}
-                {/*<th>Max Countries</th>*/}
-                {/*<th>Years</th>*/}
-                {/*<th>Ages</th>*/}
-                {/*<th>Cohorts</th>*/}
-                {/*<th>Outcomes</th>*/}
-                {/*<th>DALYs</th>*/}
-            </tr>
-            </thead>
-            <tbody>
-            {this.state.data.map(function (model: ResearchModel, index: number) {
-                return (
-                    <tr key={index} data-item={model}>
-                        <td data-title="group">{model.modelling_group}</td>
-                        <td data-title="name">{model.id}</td>
-                    </tr>
-                );
-            })}
-            </tbody>
-        </table>
+        return <div>
+            <p>Click on a column header to sort</p>
+            <table>
+                <thead>
+                <tr>
+                    <th className="sortable" onClick={() => this.onSort('modelling_group')}>Group</th>
+                    <th className="sortable" onClick={() => this.onSort('id')}>Model Name</th>
+                    {/*<th onClick={() => this.onSort('disease')}>Disease</th>*/}
+                    {/*<th onClick={() => this.onSort('type')}>Model Type</th>*/}
+                    {/*<th onClick={() => this.onSort('code')}>Code</th>*/}
+                    {/*<th>Max Countries</th>*/}
+                    {/*<th>Years</th>*/}
+                    {/*<th>Ages</th>*/}
+                    {/*<th>Cohorts</th>*/}
+                    {/*<th>Outcomes</th>*/}
+                    {/*<th>DALYs</th>*/}
+                </tr>
+                </thead>
+                <tbody>
+                {this.state.data.map(function (model: ResearchModel, index: number) {
+                    return (
+                        <tr key={index} data-item={model}>
+                            <td data-title="group">{model.modelling_group}</td>
+                            <td data-title="name">{model.id}</td>
+                        </tr>
+                    );
+                })}
+                </tbody>
+            </table>
+        </div>
+
     }
 }
 

--- a/app/src/main/admin/reducers/modellingGroupsReducer.ts
+++ b/app/src/main/admin/reducers/modellingGroupsReducer.ts
@@ -1,7 +1,6 @@
 import { ModellingGroupsAction, ModellingGroupTypes } from "../actionTypes/ModellingGroupsTypes";
 import {ErrorInfo, ModellingGroup, ModellingGroupDetails, ResearchModel, User} from "../../shared/models/Generated";
 import {isNonEmptyArray} from "../../shared/ArrayHelpers";
-import {act} from "react-dom/test-utils";
 
 export interface ModellingGroupsState {
     groups: ModellingGroup[];

--- a/app/src/main/admin/reducers/modellingGroupsReducer.ts
+++ b/app/src/main/admin/reducers/modellingGroupsReducer.ts
@@ -1,6 +1,7 @@
 import { ModellingGroupsAction, ModellingGroupTypes } from "../actionTypes/ModellingGroupsTypes";
-import {ErrorInfo, ModellingGroup, ModellingGroupDetails, User} from "../../shared/models/Generated";
+import {ErrorInfo, ModellingGroup, ModellingGroupDetails, ResearchModel, User} from "../../shared/models/Generated";
 import {isNonEmptyArray} from "../../shared/ArrayHelpers";
+import {act} from "react-dom/test-utils";
 
 export interface ModellingGroupsState {
     groups: ModellingGroup[];
@@ -9,6 +10,7 @@ export interface ModellingGroupsState {
     currentGroupMembers: User[];
     createGroupErrors: ErrorInfo[];
     showCreateGroupForm: boolean;
+    models: ResearchModel[];
 }
 
 export const modellingGroupInitialState: ModellingGroupsState = {
@@ -17,12 +19,15 @@ export const modellingGroupInitialState: ModellingGroupsState = {
     currentGroupDetails: null,
     currentGroupMembers: [],
     createGroupErrors: [],
-    showCreateGroupForm: false
+    showCreateGroupForm: false,
+    models: []
 };
 
 export const modellingGroupsReducer = (state = modellingGroupInitialState, action: ModellingGroupsAction)
     : ModellingGroupsState => {
     switch (action.type) {
+        case ModellingGroupTypes.MODELS_FETCHED:
+            return {...state, models: action.data};
         case ModellingGroupTypes.GROUPS_FETCHED:
             return {...state, groups: isNonEmptyArray(action.data) ? action.data : [] };
         case ModellingGroupTypes.SET_CURRENT_GROUP:

--- a/app/src/main/contrib/reducers/modellingGroupsReducer.ts
+++ b/app/src/main/contrib/reducers/modellingGroupsReducer.ts
@@ -1,5 +1,5 @@
-import { ModellingGroupsAction, ModellingGroupTypes } from "../actionTypes/ModellingGroupsTypes";
-import { ModellingGroup } from "../../shared/models/Generated";
+import {ModellingGroupsAction, ModellingGroupTypes} from "../actionTypes/ModellingGroupsTypes";
+import {ModellingGroup} from "../../shared/models/Generated";
 
 export interface ModellingGroupsState {
     userGroups: ModellingGroup[];

--- a/app/src/main/shared/services/ModellingGroupsService.ts
+++ b/app/src/main/shared/services/ModellingGroupsService.ts
@@ -8,6 +8,11 @@ export class ModellingGroupsService extends AbstractLocalService {
             .get("/modelling-groups/");
     }
 
+    getAllModels() {
+        return this.setOptions({cacheKey: ModellingGroupsCacheKeysEnum.models})
+            .get("/models/");
+    }
+
     getUserGroups() {
         return this.setOptions({cacheKey: ModellingGroupsCacheKeysEnum.userGroups})
             .get("/user/modelling-groups/");
@@ -48,6 +53,7 @@ export class ModellingGroupsService extends AbstractLocalService {
 }
 
 export enum ModellingGroupsCacheKeysEnum {
+    models = "models",
     groups = "groups",
     groupsDetails = "groupsDetails",
     userGroups = "userGroups"

--- a/app/src/main/shared/services/ModellingGroupsService.ts
+++ b/app/src/main/shared/services/ModellingGroupsService.ts
@@ -1,5 +1,5 @@
 import { AbstractLocalService } from "./AbstractLocalService";
-import {AssociateUser, ModellingGroupCreation} from "../models/Generated";
+import {AssociateUser, ModellingGroupCreation, ResearchModel} from "../models/Generated";
 
 export class ModellingGroupsService extends AbstractLocalService {
 
@@ -8,7 +8,7 @@ export class ModellingGroupsService extends AbstractLocalService {
             .get("/modelling-groups/");
     }
 
-    getAllModels() {
+    getAllModels(): Promise<ResearchModel[]> {
         return this.setOptions({cacheKey: ModellingGroupsCacheKeysEnum.models})
             .get("/models/");
     }

--- a/app/src/main/shared/styles/common.scss
+++ b/app/src/main/shared/styles/common.scss
@@ -15,13 +15,13 @@ html, body {
 }
 
 select, input {
-    font-size: inherit;
+  font-size: inherit;
 }
 
 table tr th, .specialColumn td:first-child {
-    background-color: rgb(170, 224, 250);
-    font-weight: bold;
-    vertical-align: top;
+  background-color: rgb(170, 224, 250);
+  font-weight: bold;
+  vertical-align: top;
 }
 
 table {
@@ -29,49 +29,74 @@ table {
   @extend .table-responsive;
   @extend .table-bordered;
 
-    // Prevent double border on horizontal scroll due to combining table-bordered and table-responsive
-    border: 0;
+  // Prevent double border on horizontal scroll due to combining table-bordered and table-responsive
+  border: 0;
+
+  th.sortable {
+    cursor: pointer;
+    position: relative;
+    padding-right: 30px;
+
+    &:after {
+      right: .5em;
+      content: "\2193";
+      position: absolute;
+      bottom: .9em;
+      display: block;
+      opacity: .3;
+    }
+
+    &:before {
+      right: 1em;
+      content: "\2191";
+      position: absolute;
+      bottom: .9em;
+      display: block;
+      opacity: .3;
+    }
+  }
+
 }
 
 hr.dashed {
-    border-bottom: 1px dashed $body-color !important;
+  border-bottom: 1px dashed $body-color !important;
 }
 
 fieldset {
-    display: inline;
-    border: none;
-    margin: 0;
-    padding: 0;
+  display: inline;
+  border: none;
+  margin: 0;
+  padding: 0;
 }
 
 .largeSectionTitle {
-    font-family: header;
-    font-size: 24pt;
-    margin: 30px 0 5px 0;
+  font-family: header;
+  font-size: 24pt;
+  margin: 30px 0 5px 0;
 }
 
 .sectionTitle {
-    font-family: header;
-    font-size: 16pt;
-    margin: 30px 0 15px 0;
+  font-family: header;
+  font-size: 16pt;
+  margin: 30px 0 15px 0;
 }
 
 .subSectionTitle {
-    font-family: header;
-    font-size: 12pt;
-    margin: 15px 0;
-    color: rgb(127, 127, 127);
+  font-family: header;
+  font-size: 12pt;
+  margin: 15px 0;
+  color: rgb(127, 127, 127);
 }
 
 .smallTitle {
-    font-family: header;
-    font-size: 12pt;
-    margin: 20px 0 5px 0;
-    color: rgb(127, 127, 127);
+  font-family: header;
+  font-size: 12pt;
+  margin: 20px 0 5px 0;
+  color: rgb(127, 127, 127);
 }
 
 .control {
-    font-size: 16pt;
+  font-size: 16pt;
 }
 
 select.form-control {
@@ -99,5 +124,5 @@ select.form-control {
 }
 
 .render-whitespace {
-    white-space: pre-line;
+  white-space: pre-line;
 }

--- a/app/src/main/shared/styles/common.scss
+++ b/app/src/main/shared/styles/common.scss
@@ -34,26 +34,28 @@ table {
 
   th.sortable {
     cursor: pointer;
-    position: relative;
-    padding-right: 30px;
 
     &:after {
-      right: .5em;
       content: "\2193";
-      position: absolute;
-      bottom: .9em;
-      display: block;
+      margin-left: .8em;
       opacity: .3;
+    }
+
+    &.desc:after {
+      opacity: 1;
     }
 
     &:before {
-      right: 1em;
       content: "\2191";
-      position: absolute;
-      bottom: .9em;
-      display: block;
       opacity: .3;
+      float: right;
+      margin-left: .1em;
     }
+
+    &.asc:before {
+      opacity: 1;
+    }
+
   }
 
 }

--- a/app/src/test/admin/actions/ModellingGroupsActionsTests.ts
+++ b/app/src/test/admin/actions/ModellingGroupsActionsTests.ts
@@ -6,6 +6,7 @@ import {createMockAdminStore, createMockStore} from "../../mocks/mockStore";
 import {ModellingGroupsService} from "../../../main/shared/services/ModellingGroupsService";
 import {ModellingGroupTypes} from "../../../main/admin/actionTypes/ModellingGroupsTypes";
 import {
+    mockModel,
     mockModellingGroup,
     mockModellingGroupCreation,
     mockModellingGroupDetails,
@@ -39,6 +40,22 @@ describe("Admin Modelling groups actions tests", () => {
             expect(getAllGroupsServiceStub.called).to.be.true;
             done();
         });
+    });
+
+    it("gets all models", async () => {
+        const testModel = mockModel();
+        const testModel2 = mockModel();
+        const store = createMockStore({});
+        const getAllGroupsServiceStub = sandbox.setStubFunc(ModellingGroupsService.prototype, "getAllModels", () => {
+            return Promise.resolve([testModel, testModel2]);
+        });
+
+        await store.dispatch(modellingGroupsActionCreators.getAllModels());
+
+        const actions = store.getActions();
+        const expectedPayload = {type: ModellingGroupTypes.MODELS_FETCHED, data: [testModel, testModel2]};
+        expect(actions).to.eql([expectedPayload]);
+        expect(getAllGroupsServiceStub.called).to.be.true;
     });
 
     it("gets group details", (done) => {
@@ -233,8 +250,10 @@ describe("Admin Modelling groups actions tests", () => {
 
     it("dispatches ADD_MODELLING_GROUP on group creation", (done) => {
 
-        const newGroup = mockModellingGroupCreation({institution: "imperial", pi: "someone new",
-        description: "imperial (someone new)"});
+        const newGroup = mockModellingGroupCreation({
+            institution: "imperial", pi: "someone new",
+            description: "imperial (someone new)"
+        });
 
         verifyActionThatCallsService(done, {
             mockServices: () => {

--- a/app/src/test/admin/actions/pages/ModelMetaPageActionsTests.ts
+++ b/app/src/test/admin/actions/pages/ModelMetaPageActionsTests.ts
@@ -1,0 +1,44 @@
+import {Sandbox} from "../../../Sandbox";
+import {mockModel} from "../../../mocks/mockModels";
+import {mockAdminState} from "../../../mocks/mockStates";
+import {createMockAdminStore} from "../../../mocks/mockStore";
+import {expect} from "chai";
+import {modelMetaPageActionCreators} from "../../../../main/admin/actions/pages/ModelMetaPageActionCreators";
+import {modellingGroupsListPageActionCreators} from "../../../../main/admin/actions/pages/ModellingGroupsListPageActionCreators";
+import {modellingGroupsActionCreators} from "../../../../main/admin/actions/modellingGroupsActionCreators";
+
+describe("modelMetaPageActionCreators", () => {
+    const sandbox = new Sandbox();
+    afterEach(() => sandbox.restore());
+
+    const model = mockModel({id: "mA"});
+    const model2 = mockModel({id: "mB"});
+
+    const state = mockAdminState({groups: {models: [model, model2]}});
+
+    it("fetches models on load", async () => {
+
+        sandbox.setStubReduxAction(modellingGroupsActionCreators, "getAllModels");
+        const store = createMockAdminStore(state);
+        await store.dispatch(modelMetaPageActionCreators.loadData());
+        expect(store.getActions()).to.eql([
+            {type: 'test'}
+        ]);
+    });
+
+    it("creates breadcrumbs", () => {
+
+        const result = modelMetaPageActionCreators.createBreadcrumb(state);
+
+        expect(result.urlFragment).to.eq("models/");
+        expect(result.name).to.eq("Model Metadata");
+    });
+
+    it("has ModellingGroupsListPage as parent", () => {
+        expect(modelMetaPageActionCreators.parent).to.eq(modellingGroupsListPageActionCreators)
+    });
+
+    it("has title", () => {
+        expect(modelMetaPageActionCreators.title()).to.eq("Model Metadata")
+    });
+});

--- a/app/src/test/admin/components/ModellingGroups/Models/ModelMetaPageTests.tsx
+++ b/app/src/test/admin/components/ModellingGroups/Models/ModelMetaPageTests.tsx
@@ -1,0 +1,25 @@
+import {Sandbox} from "../../../../Sandbox";
+import {mockPageProperties, shallowRenderPage} from "../../../../mocks/mockPages";
+import {expect} from "chai";
+import {PageArticle} from "../../../../../main/shared/components/PageWithHeader/PageArticle";
+import * as React from "react";
+import {modelMetaPageActionCreators} from "../../../../../main/admin/actions/pages/ModelMetaPageActionCreators";
+import {
+    ModelMetaPage,
+} from "../../../../../main/admin/components/ModellingGroups/Models/ModelMetaPage";
+import {ModelMetaTable} from "../../../../../main/admin/components/ModellingGroups/Models/ModelMetaTable";
+
+describe("ModelMetaPage", () => {
+    const sandbox = new Sandbox();
+    afterEach(() => sandbox.restore());
+
+    it("renders page with correct action creators", () => {
+        const onLoadStub = sandbox.setStubReduxAction(modelMetaPageActionCreators, "onLoad");
+        const rendered = shallowRenderPage(<ModelMetaPage {...mockPageProperties()} />);
+
+        expect(rendered.find(PageArticle).props().title).to.eq("Model Metadata");
+        expect(rendered.find(PageArticle).find(ModelMetaTable)).to.have.length(1);
+        expect(onLoadStub.called).is.equal(true);
+    });
+
+});

--- a/app/src/test/admin/components/ModellingGroups/Models/ModelMetaTableTests.tsx
+++ b/app/src/test/admin/components/ModellingGroups/Models/ModelMetaTableTests.tsx
@@ -64,11 +64,16 @@ describe("ModelMetaTable tests", () => {
 
         // ascending
         expect(getFirstGroup()).to.eq("ga");
+        expect(rendered.find("th").at(0).hasClass("asc")).to.eq(true);
+        expect(rendered.find("th").at(0).hasClass("desc")).to.eq(false);
+
 
         rendered.find("th").at(0).simulate("click");
 
         // descending
         expect(getFirstGroup()).to.eq("gb");
+        expect(rendered.find("th").at(0).hasClass("asc")).to.eq(false);
+        expect(rendered.find("th").at(0).hasClass("desc")).to.eq(true);
     });
 
 
@@ -87,11 +92,15 @@ describe("ModelMetaTable tests", () => {
 
         // ascending
         expect(getFirstModel()).to.eq("ma");
+        expect(rendered.find("th").at(1).hasClass("asc")).to.eq(true);
+        expect(rendered.find("th").at(1).hasClass("desc")).to.eq(false);
 
         rendered.find("th").at(1).simulate("click");
 
         // descending
         expect(getFirstModel()).to.eq("mb");
+        expect(rendered.find("th").at(1).hasClass("asc")).to.eq(false);
+        expect(rendered.find("th").at(1).hasClass("desc")).to.eq(true);
     });
 
 });

--- a/app/src/test/admin/components/ModellingGroups/Models/ModelMetaTableTests.tsx
+++ b/app/src/test/admin/components/ModellingGroups/Models/ModelMetaTableTests.tsx
@@ -1,0 +1,97 @@
+import {mockModel} from "../../../../mocks/mockModels";
+import {Sandbox} from "../../../../Sandbox";
+import {createMockStore} from "../../../../mocks/mockStore";
+import {shallow} from "enzyme";
+import {expect} from "chai";
+import * as React from "react";
+import {ModelMetaTable,} from "../../../../../main/admin/components/ModellingGroups/Models/ModelMetaTable";
+
+describe("ModelMetaTable tests", () => {
+
+    const testModel = mockModel({id: 'mb', modelling_group: "ga"});
+    const testModel2 = mockModel({id: 'ma', modelling_group: "gb"});
+
+    const sandbox = new Sandbox();
+    afterEach(() => sandbox.restore());
+
+    it("gets props from state", () => {
+        const testState = {
+            groups: {models: [testModel, testModel2]}
+        };
+        const store = createMockStore(testState);
+        const rendered = shallow(<ModelMetaTable/>, {context: {store}});
+        expect(rendered.props().models).to.eql([testModel, testModel2]);
+    });
+
+
+    it("displays table of models", () => {
+        const testState = {
+            groups: {models: [testModel, testModel2]}
+        };
+        const store = createMockStore(testState);
+        const rendered = shallow(<ModelMetaTable/>, {context: {store}}).dive();
+
+        expect(rendered.find("th")).to.have.lengthOf(2);
+        expect(rendered.find("th").at(0).text()).to.eq("Group");
+        expect(rendered.find("th").at(1).text()).to.eq("Model Name");
+
+        const body = rendered.find("tbody");
+
+        expect(body.find("tr")).to.have.lengthOf(2);
+
+        function cellsForRow(i: number) {
+            return body.find("tr").at(i).find("td");
+        }
+        expect(cellsForRow(0).at(0).text()).to.eq("ga");
+        expect(cellsForRow(0).at(1).text()).to.eq("mb");
+
+        expect(cellsForRow(1).at(0).text()).to.eq("gb");
+        expect(cellsForRow(1).at(1).text()).to.eq("ma");
+    });
+
+    it("sorts by group", () => {
+        const testState = {
+            groups: {models: [testModel, testModel2]}
+        };
+        const store = createMockStore(testState);
+        const rendered = shallow(<ModelMetaTable/>, {context: {store}}).dive();
+
+        function getFirstGroup() {
+            return rendered.find("tbody").find("tr").at(0).find("td").at(0).text()
+        }
+
+        rendered.find("th").at(0).simulate("click");
+
+        // ascending
+        expect(getFirstGroup()).to.eq("ga");
+
+        rendered.find("th").at(0).simulate("click");
+
+        // descending
+        expect(getFirstGroup()).to.eq("gb");
+    });
+
+
+    it("sorts by name", () => {
+        const testState = {
+            groups: {models: [testModel, testModel2]}
+        };
+        const store = createMockStore(testState);
+        const rendered = shallow(<ModelMetaTable/>, {context: {store}}).dive();
+
+        function getFirstModel() {
+            return rendered.find("tbody").find("tr").at(0).find("td").at(1).text()
+        }
+
+        rendered.find("th").at(1).simulate("click");
+
+        // ascending
+        expect(getFirstModel()).to.eq("ma");
+
+        rendered.find("th").at(1).simulate("click");
+
+        // descending
+        expect(getFirstModel()).to.eq("mb");
+    });
+
+});

--- a/app/src/test/admin/reducers/ModellingGroupsReducerTests.ts
+++ b/app/src/test/admin/reducers/ModellingGroupsReducerTests.ts
@@ -2,7 +2,7 @@ import { expect } from "chai";
 
 import {modellingGroupInitialState, modellingGroupsReducer} from "../../../main/admin/reducers/modellingGroupsReducer";
 import {AddModellingGroup, ModellingGroupTypes} from "../../../main/admin/actionTypes/ModellingGroupsTypes";
-import {mockModellingGroup, mockModellingGroupDetails, mockUser} from "../../mocks/mockModels";
+import {mockModel, mockModellingGroup, mockModellingGroupDetails, mockUser} from "../../mocks/mockModels";
 
 describe('Admin Modelling Groups reducer tests', () => {
 
@@ -16,6 +16,15 @@ describe('Admin Modelling Groups reducer tests', () => {
             type: ModellingGroupTypes.GROUPS_FETCHED,
             data: [testGroup, testGroup2]
         })).to.eql({...modellingGroupInitialState, groups: [testGroup, testGroup2]});
+    });
+
+    it('sets fetched models', () => {
+        const model1 = mockModel();
+        const model2 = mockModel();
+        expect(modellingGroupsReducer(undefined, {
+            type: ModellingGroupTypes.MODELS_FETCHED,
+            data: [model1, model2]
+        })).to.eql({...modellingGroupInitialState, models: [model1, model2]});
     });
 
     it('sets fetched groups empty ', () => {

--- a/app/src/test/mocks/mockModels.ts
+++ b/app/src/test/mocks/mockModels.ts
@@ -32,6 +32,17 @@ export function mockScenario(properties?: Partial<models.Scenario>): models.Scen
     return Object.assign(template, properties);
 }
 
+export function mockModel(properties?: Partial<models.ResearchModel>) {
+    counter++;
+    const template: models.ResearchModel = {
+        id: "model-" + counter,
+        description: "Description",
+        citation: "citation",
+        modelling_group: "group-" + counter
+    };
+    return Object.assign(template, properties);
+}
+
 export function mockModellingGroup(properties?: Partial<models.ModellingGroup>) {
     counter++;
     const template: models.ModellingGroup = {


### PR DESCRIPTION
This adds a super simple table with the existing model meta. To be extended once the richer endpoints have been added.

Note this adds the route so it can be viewed by manually navigating to the url `/modelling-groups/models/` but does not link it from anywhere, idea being we wait til it's finished to actually link to it.