### PR TITLE
Vimc 3081 show model metadata outcome details in tooltip

### DIFF
--- a/app/config/api_version
+++ b/app/config/api_version
@@ -1,1 +1,1 @@
-master
+VIMC-3081

--- a/app/config/api_version
+++ b/app/config/api_version
@@ -1,1 +1,1 @@
-VIMC-3081
+master

--- a/app/src/integrationTests/AdminIntegrationTests.tsx
+++ b/app/src/integrationTests/AdminIntegrationTests.tsx
@@ -461,7 +461,7 @@ const expectedResponsibilitySets: ResponsibilitySetWithExpectations[] = [{
                 countries: [],
                 description: "bee desc",
                 id: 1,
-                outcomes: ["cases", "deaths"],
+                outcomes: [{code: "cases", name: "cases"},{code: "deaths", name: "deaths"}],
                 years: {
                     minimum_inclusive: 1950,
                     maximum_inclusive: 2100

--- a/app/src/integrationTests/AdminIntegrationTests.tsx
+++ b/app/src/integrationTests/AdminIntegrationTests.tsx
@@ -121,7 +121,7 @@ class AdminIntegrationTests extends IntegrationTestSuite {
                         minimum_birth_year: 1900,
                         maximum_birth_year: 2100
                     },
-                    outcomes: ["cases", "deaths"]
+                    outcomes: [{code: "cases", name: "cases"}, {code: "deaths", name: "deaths"}]
                 },
                 applicable_scenarios: [scenarioId]
             }]);

--- a/app/src/main/admin/components/ModellingGroups/Models/ModelMetaTable.tsx
+++ b/app/src/main/admin/components/ModellingGroups/Models/ModelMetaTable.tsx
@@ -161,7 +161,7 @@ export class ModelMetaTableComponent extends React.Component<ModelMetaProps, Sta
                     const outcomesDetailsTooltip = model.outcomes.length > 0 ?
                         createTooltip(`outcomes-details-link-${index}`,
                             model.outcomes_details.map(function(outcome: Outcome) {
-                                return (<div>{`${outcome.code} (${outcome.name})`}</div>);
+                                return (<div>{`${outcome.code}: ${outcome.name}`}</div>);
                             }))
                         : "";
 

--- a/app/src/main/admin/components/ModellingGroups/Models/ModelMetaTable.tsx
+++ b/app/src/main/admin/components/ModellingGroups/Models/ModelMetaTable.tsx
@@ -158,7 +158,7 @@ export class ModelMetaTableComponent extends React.Component<ModelMetaProps, Sta
                             }))
                         : "";
 
-                    const outcomesDetailsTooltip = model.outcomes.length > 0 ?
+                    const outcomesDetailsTooltip = model.outcomes_details.length > 0 ?
                         createTooltip(`outcomes-details-link-${index}`,
                             model.outcomes_details.map(function(outcome: Outcome) {
                                 return (<div>{`${outcome.code}: ${outcome.name}`}</div>);

--- a/app/src/main/admin/components/ModellingGroups/Models/ModelMetaTable.tsx
+++ b/app/src/main/admin/components/ModellingGroups/Models/ModelMetaTable.tsx
@@ -134,34 +134,34 @@ export class ModelMetaTableComponent extends React.Component<ModelMetaProps, Sta
                 <tbody>
                 {this.state.data.map(function (model: ModelMetaRow, index: number) {
                     const scenarioDetailsLink = model.scenario_count > 0 ?
-                        <div><a href="#" id={`scenario-details-link-${index}`}>view</a></div> : "";
+                        <div key={`scenario-details-${index}`}><a href="#" id={`scenario-details-link-${index}`}>view</a></div> : "";
 
                     const countriesDetailsLink = model.max_countries > 0 ?
-                        <div><a href="#" id={`countries-details-link-${index}`}>view</a></div> : "";
+                        <div key={`countries-details-${index}`}><a href="#" id={`countries-details-link-${index}`}>view</a></div> : "";
 
 
                     const outcomesDetailsLink = model.outcomes_details.length > 0   ?
-                        <div><a href="#" id={`outcomes-details-link-${index}`}>definitions</a></div> : "";
+                        <div key={`outcomes-details-${index}`}><a href="#" id={`outcomes-details-link-${index}`}>definitions</a></div> : "";
 
 
                     const scenarioDetailsTooltip = model.scenario_count > 0 ?
                         createTooltip(`scenario-details-link-${index}`,
-                            model.scenarios.map(function(scenario: string) {
-                                return (<div>{scenario}</div>);
+                            model.scenarios.map(function(scenario: string, scenarioIdx: number) {
+                                return (<div key={`scenario-${index}-${scenarioIdx}`}>{scenario}</div>);
                             }))
                         : "";
 
                     const countriesDetailsTooltip = model.max_countries > 0 ?
                         createTooltip(`countries-details-link-${index}`,
-                            model.countries.map(function(country: Country) {
-                                return (<div>{`${country.name} (${country.id})`}</div>);
+                            model.countries.map(function(country: Country, countryIdx: number) {
+                                return (<div key={`country-${index}-${countryIdx}`}>{`${country.name} (${country.id})`}</div>);
                             }))
                         : "";
 
                     const outcomesDetailsTooltip = model.outcomes_details.length > 0 ?
                         createTooltip(`outcomes-details-link-${index}`,
-                            model.outcomes_details.map(function(outcome: Outcome) {
-                                return (<div><strong>{`${outcome.code}: `}</strong>{`${outcome.name}`}</div>);
+                            model.outcomes_details.map(function(outcome: Outcome, outcomeIdx: number) {
+                                return (<div key={`outcome-${index}-${outcomeIdx}`}><strong>{`${outcome.code}: `}</strong>{`${outcome.name}`}</div>);
                             }))
                         : "";
 

--- a/app/src/main/admin/components/ModellingGroups/Models/ModelMetaTable.tsx
+++ b/app/src/main/admin/components/ModellingGroups/Models/ModelMetaTable.tsx
@@ -161,7 +161,7 @@ export class ModelMetaTableComponent extends React.Component<ModelMetaProps, Sta
                     const outcomesDetailsTooltip = model.outcomes_details.length > 0 ?
                         createTooltip(`outcomes-details-link-${index}`,
                             model.outcomes_details.map(function(outcome: Outcome) {
-                                return (<div>{`${outcome.code}: ${outcome.name}`}</div>);
+                                return (<div><strong>{`${outcome.code}: `}</strong>{`${outcome.name}`}</div>);
                             }))
                         : "";
 

--- a/app/src/main/admin/components/ModellingGroups/Models/ModelMetaTable.tsx
+++ b/app/src/main/admin/components/ModellingGroups/Models/ModelMetaTable.tsx
@@ -3,7 +3,7 @@ import {AdminAppState} from "../../../reducers/adminAppReducers";
 import {connect} from "react-redux";
 import {ILookup} from "../../../../shared/models/Lookup";
 import {UncontrolledTooltip} from "reactstrap";
-import {Country} from "../../../../shared/models/Generated";
+import {Country, Outcome} from "../../../../shared/models/Generated";
 
 interface ModelMetaRow {
     code: string | null
@@ -19,6 +19,7 @@ interface ModelMetaRow {
     ages: string;
     cohorts: string;
     outcomes: string;
+    outcomes_details: Outcome[];
     has_dalys: boolean;
     scenario_count: number;
     scenarios: string[];
@@ -138,6 +139,11 @@ export class ModelMetaTableComponent extends React.Component<ModelMetaProps, Sta
                     const countriesDetailsLink = model.max_countries > 0 ?
                         <div><a href="#" id={`countries-details-link-${index}`}>view</a></div> : "";
 
+
+                    const outcomesDetailsLink = model.outcomes_details.length > 0   ?
+                        <div><a href="#" id={`outcomes-details-link-${index}`}>definitions</a></div> : "";
+
+
                     const scenarioDetailsTooltip = model.scenario_count > 0 ?
                         createTooltip(`scenario-details-link-${index}`,
                             model.scenarios.map(function(scenario: string) {
@@ -149,6 +155,13 @@ export class ModelMetaTableComponent extends React.Component<ModelMetaProps, Sta
                         createTooltip(`countries-details-link-${index}`,
                             model.countries.map(function(country: Country) {
                                 return (<div>{`${country.name} (${country.id})`}</div>);
+                            }))
+                        : "";
+
+                    const outcomesDetailsTooltip = model.outcomes.length > 0 ?
+                        createTooltip(`outcomes-details-link-${index}`,
+                            model.outcomes_details.map(function(outcome: Outcome) {
+                                return (<div>{`${outcome.code} (${outcome.name})`}</div>);
                             }))
                         : "";
 
@@ -169,10 +182,13 @@ export class ModelMetaTableComponent extends React.Component<ModelMetaProps, Sta
                             <td data-title="years">{model.years}</td>
                             <td data-title="ages">{model.ages}</td>
                             <td data-title="cohorts">{model.cohorts}</td>
-                            <td data-title="outcomes">{model.outcomes}</td>
+                            <td data-title="outcomes">{model.outcomes}
+                                {outcomesDetailsLink}
+                            </td>
                             <td data-title="dalys">{model.has_dalys ? "Yes" : "No"}</td>
                             {scenarioDetailsTooltip}
                             {countriesDetailsTooltip}
+                            {outcomesDetailsTooltip}
                         </tr>
                     );
                 })}
@@ -220,6 +236,7 @@ export const mapStateToProps = (state: AdminAppState): ModelMetaProps => {
                 return {
                     ...modelValues,
                     outcomes: outcome_codes.join(", "),
+                    outcomes_details: expectation.outcomes,
                     has_dalys: outcome_codes.indexOf("dalys") > -1,
                     years: `${expectation.years.minimum_inclusive} - ${expectation.years.maximum_inclusive}`,
                     ages: `${expectation.ages.minimum_inclusive} - ${expectation.ages.maximum_inclusive}`,
@@ -231,6 +248,7 @@ export const mapStateToProps = (state: AdminAppState): ModelMetaProps => {
                 return {
                     ...modelValues,
                     outcomes: expectationNotFound,
+                    outcomes_details: [],
                     has_dalys: false,
                     years: expectationNotFound,
                     ages: expectationNotFound,

--- a/app/src/main/admin/components/ModellingGroups/Models/ModelMetaTable.tsx
+++ b/app/src/main/admin/components/ModellingGroups/Models/ModelMetaTable.tsx
@@ -215,10 +215,12 @@ export const mapStateToProps = (state: AdminAppState): ModelMetaProps => {
                         (expectation.cohorts.maximum_birth_year) ? `Max ${expectation.cohorts.maximum_birth_year}` :
                             "Any";
 
+                const outcome_codes = expectation.outcomes.map(o => o.code)
+
                 return {
                     ...modelValues,
-                    outcomes: expectation.outcomes.join(", "),
-                    has_dalys: expectation.outcomes.indexOf("dalys") > -1,
+                    outcomes: outcome_codes.join(", "),
+                    has_dalys: outcome_codes.indexOf("dalys") > -1,
                     years: `${expectation.years.minimum_inclusive} - ${expectation.years.maximum_inclusive}`,
                     ages: `${expectation.ages.minimum_inclusive} - ${expectation.ages.maximum_inclusive}`,
                     cohorts: cohorts,

--- a/app/src/main/admin/style.scss
+++ b/app/src/main/admin/style.scss
@@ -11,6 +11,7 @@
 
   th {
     padding-right: 1.8em;
+    background-clip: padding-box;
   }
 }
 

--- a/app/src/main/admin/style.scss
+++ b/app/src/main/admin/style.scss
@@ -19,7 +19,9 @@
   background-color: white;
   border: 1px solid #c8c8c8;
   max-height:200px!important;
+  max-width:350px!important;
   overflow-y:auto!important;
+  text-align:left!important;
 }
 
 .model-meta-tooltip > .arrow::before {

--- a/app/src/main/contrib/components/Responsibilities/Expectations/ExpectationsDescription.tsx
+++ b/app/src/main/contrib/components/Responsibilities/Expectations/ExpectationsDescription.tsx
@@ -41,7 +41,7 @@ export class ExpectationsDescription extends React.PureComponent<ExpectationsDes
                 Expecting data on:
                 <ul id={"outcomes"}>
                     <li>cohort_size</li>
-                    {expectation.outcomes.map(o => <li key={o}>{o}</li>)}
+                    {expectation.outcomes.map(o => <li key={o.code}>{o.code}</li>)}
                 </ul>
                 For all combinations of:
                 <ul>

--- a/app/src/main/shared/models/Generated.ts
+++ b/app/src/main/shared/models/Generated.ts
@@ -121,12 +121,17 @@ export interface ResearchModelDetails {
     modelling_group: string;
 }
 
+export interface Outcome {
+    code: string;
+    name: string;
+}
+
 export interface Expectations {
     ages: NumberRange;
     cohorts: CohortRestriction;
     description: string;
     id: number;
-    outcomes: string[];
+    outcomes: Outcome[];
     years: NumberRange;
 }
 
@@ -142,7 +147,7 @@ export interface CountryOutcomeExpectations extends Expectations {
     countries: Country[];
     description: string;
     id: number;
-    outcomes: string[];
+    outcomes: Outcome[];
     years: NumberRange;
 }
 
@@ -156,6 +161,7 @@ export type BurdenEstimateSetStatus = "empty" | "partial" | "complete" | "invali
 
 export interface BurdenEstimateSet {
     id: number;
+    original_filename: string | null;
     problems: string[];
     status: BurdenEstimateSetStatus;
     type: BurdenEstimateSetType;
@@ -235,7 +241,7 @@ export interface OutcomeExpectations extends Expectations {
     cohorts: CohortRestriction;
     description: string;
     id: number;
-    outcomes: string[];
+    outcomes: Outcome[];
     years: NumberRange;
 }
 

--- a/app/src/main/shared/styles/common.scss
+++ b/app/src/main/shared/styles/common.scss
@@ -42,7 +42,7 @@ table {
       margin-left: .8em;
       opacity: .3;
       position: absolute;
-      bottom: 0.9em;
+      top: 0.6em;
       right: 0.5em
     }
 
@@ -55,7 +55,7 @@ table {
       opacity: .3;
       margin-left: .1em;
       position: absolute;
-      bottom: 0.9em;
+      top: 0.6em;
       right: 1em
     }
 

--- a/app/src/test/admin/components/ModellingGroups/Models/ModelMetaTableTests.tsx
+++ b/app/src/test/admin/components/ModellingGroups/Models/ModelMetaTableTests.tsx
@@ -42,7 +42,7 @@ describe("ModelMetaTable tests", () => {
             years: { minimum_inclusive: 1900, maximum_inclusive: 2000},
             ages: { minimum_inclusive: 0, maximum_inclusive: 99},
             cohorts: { minimum_birth_year: null, maximum_birth_year: 2000 },
-            outcomes: ["deaths", "dalys"]
+            outcomes: [ {code: "deaths", name: "deaths name"}, {code: "dalys", name: "dalys name"}]
         })
     });
     const testExpectation2 = mockTouchstoneModelExpectations({
@@ -54,7 +54,7 @@ describe("ModelMetaTable tests", () => {
             years: { minimum_inclusive: 1950, maximum_inclusive: 2000},
             ages: { minimum_inclusive: 0, maximum_inclusive: 49},
             cohorts: { minimum_birth_year: 1900, maximum_birth_year: 2000 },
-            outcomes: ["deaths", "cases"]
+            outcomes: [{code: "deaths", name: "deaths name"}, {code: "cases", name: "cases name"}]
         })
     });
 
@@ -110,7 +110,7 @@ describe("ModelMetaTable tests", () => {
                 years: { minimum_inclusive: 1910, maximum_inclusive: 2100},
                 ages: { minimum_inclusive: 1, maximum_inclusive: 90},
                 cohorts: { minimum_birth_year: 1800, maximum_birth_year: 1900 },
-                outcomes: ["deaths2", "dalys2"]
+                outcomes: [{code: "deaths2", name: "deaths2"}, {code: "dalys2", name: "dalys2"}]
             })
         });
         const earlierExpectation2 = mockTouchstoneModelExpectations({
@@ -121,7 +121,7 @@ describe("ModelMetaTable tests", () => {
                 years: { minimum_inclusive: 1951, maximum_inclusive: 20010},
                 ages: { minimum_inclusive: 1, maximum_inclusive: 41},
                 cohorts: { minimum_birth_year: 1901, maximum_birth_year: 2001 },
-                outcomes: ["deaths2", "cases2"]
+                outcomes: [{code: "deaths2", name: "deaths2"}, {code: "cases2", name: "cases2"}]
             })
         });
 

--- a/app/src/test/admin/components/ModellingGroups/Models/ModelMetaTableTests.tsx
+++ b/app/src/test/admin/components/ModellingGroups/Models/ModelMetaTableTests.tsx
@@ -67,6 +67,7 @@ describe("ModelMetaTable tests", () => {
             ages: "0 - 99",
             cohorts: "Max 2000",
             outcomes: "deaths, dalys",
+            outcomes_details: [{code: "deaths", name: "deaths name"}, {code: "dalys", name: "dalys name"}],
             has_dalys: true,
             max_countries: 2,
             scenario_count: 1,
@@ -81,6 +82,7 @@ describe("ModelMetaTable tests", () => {
             ages: "0 - 49",
             cohorts: "1900 - 2000",
             outcomes: "deaths, cases",
+            outcomes_details: [{code: "deaths", name: "deaths name"}, {code: "cases", name: "cases name"}],
             has_dalys: false,
             max_countries: 1,
             scenario_count: 2,
@@ -177,7 +179,7 @@ describe("ModelMetaTable tests", () => {
         expect(cellsForRow(0).at(8).text()).to.eq("1900 - 2000");
         expect(cellsForRow(0).at(9).text()).to.eq("0 - 99");
         expect(cellsForRow(0).at(10).text()).to.eq("Max 2000");
-        expect(cellsForRow(0).at(11).text()).to.eq("deaths, dalys");
+        expect(cellsForRow(0).at(11).text()).to.eq("deaths, dalys" + "definitions");
         expect(cellsForRow(0).at(12).text()).to.eq("Yes");
 
         expect(cellsForRow(1).at(0).text()).to.eq("gb");
@@ -191,7 +193,7 @@ describe("ModelMetaTable tests", () => {
         expect(cellsForRow(1).at(8).text()).to.eq("1950 - 2000");
         expect(cellsForRow(1).at(9).text()).to.eq("0 - 49");
         expect(cellsForRow(1).at(10).text()).to.eq("1900 - 2000");
-        expect(cellsForRow(1).at(11).text()).to.eq("deaths, cases");
+        expect(cellsForRow(1).at(11).text()).to.eq("deaths, cases" + "definitions");
         expect(cellsForRow(1).at(12).text()).to.eq("No");
     });
 
@@ -240,7 +242,7 @@ describe("ModelMetaTable tests", () => {
     });
 
     it("sorts by outcomes", () => {
-        assertSortsBy(11, "deaths, cases", "deaths, dalys")
+        assertSortsBy(11, "deaths, cases" + "definitions", "deaths, dalys" + "definitions")
     });
 
     it("sorts by has dalys", () => {
@@ -255,6 +257,11 @@ describe("ModelMetaTable tests", () => {
     it("shows countries tooltips", () => {
         assertTooltip(7, 0, "countries-details-link-0", ["Country1 (AA)","Country2 (AB)"]);
         assertTooltip(7, 1, "countries-details-link-1", ["Country1 (AA)"]);
+    });
+
+    it ("shows outcomes tooltips", () => {
+        assertTooltip(11, 0, "outcomes-details-link-0", ["deaths: deaths name", "dalys: dalys name"]);
+        assertTooltip(11, 1, "outcomes-details-link-1", ["deaths: deaths name","cases: cases name"]);
     });
 
     function assertSortsBy(colIndex: number, ascValue: string, descValue: string) {
@@ -288,6 +295,7 @@ describe("ModelMetaTable tests", () => {
         const rendered = shallow(<ModelMetaTable/>, {context: {store}}).dive();
 
         const row =  rendered.find("tbody").find("tr").at(rowIndex);
+
         const cell = row.find("td").at(colIndex);
         const link = cell.find("a");
         expect(link.prop("id")).to.eql(target);

--- a/app/src/test/contrib/components/Responsibilities/Expectations/ExpectationsDescriptionTests.tsx
+++ b/app/src/test/contrib/components/Responsibilities/Expectations/ExpectationsDescriptionTests.tsx
@@ -141,7 +141,8 @@ describe("ExpectationsDescription", () => {
 
     it("renders outcomes", () => {
         const expectation: ExpectationMapping = {
-            expectation: mockExpectations({outcomes: ["deaths", "cases"]}),
+            expectation: mockExpectations({outcomes: [{code: "deaths", name:"deaths"},
+                                                                {code: "cases", name: "cases"}]}),
             applicable_scenarios: ["a", "b", "c"],
             disease: "YF"
         };

--- a/app/src/test/mocks/mockModels.ts
+++ b/app/src/test/mocks/mockModels.ts
@@ -69,7 +69,7 @@ export function mockOutcomeExpectations(properties?: Partial<models.OutcomeExpec
         cohorts: {maximum_birth_year: 2000, minimum_birth_year: 1900},
         description: "Description",
         id: counter,
-        outcomes: ["deaths", "dalys"],
+        outcomes: [ {code: "deaths", name: "deaths name"}, {code: "dalys", name: "dalys name"}],
         years: { maximum_inclusive: 2100, minimum_inclusive: 1900 }
     };
     return Object.assign(template,properties);
@@ -180,7 +180,7 @@ export function mockExpectations(properties?: Partial<models.CountryOutcomeExpec
         years: {minimum_inclusive: 2000, maximum_inclusive: 2100},
         cohorts: {minimum_birth_year: 2000, maximum_birth_year: 2050},
         countries: [mockCountry(), mockCountry()],
-        outcomes: ["deaths", "cases"]
+        outcomes: [{code: "deaths", name: "deaths"}, {code: "cases", name: "cases"}]
     };
     return Object.assign(template, properties);
 }
@@ -292,7 +292,8 @@ export function mockBurdenEstimateSet(properties?: Partial<models.BurdenEstimate
             type: "central-single-run",
             details: "Run number 64"
         },
-        status: "complete"
+        status: "complete",
+        original_filename: "test.csv"
     };
     return Object.assign(template, properties);
 }

--- a/app/src/test/shared/components/PageArticleTests.tsx
+++ b/app/src/test/shared/components/PageArticleTests.tsx
@@ -13,14 +13,16 @@ describe("PageArticle", () => {
     it("renders a fluid container if isFluid", () => {
         const rendered = shallow(<PageArticle title={"test title"} isFluid={true} children={"test content"}/>);
         const article = rendered.find("article");
-        expect(article.hasClass("fluid-container")).to.equal(true);
+        expect(article.hasClass("container-fluid")).to.equal(true);
+        expect(article.hasClass("container-fit")).to.equal(true);
         expect(article.hasClass("container")).to.equal(false);
     });
 
     it("renders nonfluid container if not isFluid", () => {
         const rendered = shallow(<PageArticle title={"test title"} isFluid={false} children={"test content"}/>);
         const article = rendered.find("article");
-        expect(article.hasClass("fluid-container")).to.equal(false);
+        expect(article.hasClass("container-fluid")).to.equal(false);
+        expect(article.hasClass("container-fit")).to.equal(false);
         expect(article.hasClass("container")).to.equal(true);
     });
 });


### PR DESCRIPTION
Contains changes from https://github.com/vimc/montagu-webapps/pull/401 which should be merged first