### PR TITLE
don't show filename if it doesn't exist

### DIFF
--- a/app/src/main/contrib/components/Responsibilities/Overview/List/CurrentEstimateSetSummary.tsx
+++ b/app/src/main/contrib/components/Responsibilities/Overview/List/CurrentEstimateSetSummary.tsx
@@ -21,17 +21,18 @@ export class CurrentEstimateSetSummary extends React.Component<CurrentEstimateSe
                 return <span>No central burden estimate sets have been uploaded.</span>;
             } else {
                 const timestamp = longTimestamp(new Date(set.uploaded_on));
+                const filename = set.original_filename ? ` with filename \"${set.original_filename}\"` : "";
                 if (set.status == "empty") {
                     return <span>
                         You registered how you calculated your central estimates on {timestamp}.
                     </span>;
                 } else if (set.status == "complete") {
                     return <span>
-                        A complete set of central estimates was uploaded on {timestamp} with filename "{set.original_filename}"
+                        A complete set of central estimates was uploaded on {timestamp} {filename}
                     </span>;
                 } else if (set.status == "invalid") {
                     return <span>
-                        You uploaded an incomplete set of central estimates on {timestamp} with filename "{set.original_filename}"
+                        You uploaded an incomplete set of central estimates on {timestamp} {filename}
                     </span>;
                 } else {
                     return <span>

--- a/app/src/test/contrib/components/Responsibilities/Overview/List/CurrentEstimateSetSummaryTests.tsx
+++ b/app/src/test/contrib/components/Responsibilities/Overview/List/CurrentEstimateSetSummaryTests.tsx
@@ -73,6 +73,16 @@ describe("CurrentEstimateSetSummary Component Tests", () => {
         expect(div.hasClass("alert-warning")).to.eq(true);
     });
 
+    it("does not display filename for complete set if it doesn't exist", () => {
+        const rendered = render(mockBurdenEstimateSet({
+            status: "complete",
+            uploaded_on: "2017-07-13 13:55:29 +0100",
+            original_filename: null
+        }), true);
+        expect(rendered.text()).to.contain("A complete set of central estimates was uploaded on Thu Jul 13");
+        expect(rendered.text()).not.to.contain("with filename \"file.csv\"");
+    });
+
     it("displays fallback message for unknown status", () => {
         const rendered = render(mockBurdenEstimateSet({
             status: "foo" as any,
@@ -99,6 +109,16 @@ describe("CurrentEstimateSetSummary Component Tests", () => {
 
         const div = rendered.find("div").first();
         expect(div.hasClass("alert-danger")).to.eq(true);
+    });
+
+    it("does not display filename for invalid set if it doesn't exist", () => {
+        const rendered = render(mockBurdenEstimateSet({
+            status: "invalid",
+            uploaded_on: "2017-07-13 13:55:29 +0100",
+            original_filename: null
+        }), true);
+        expect(rendered.text()).to.contain("You uploaded an incomplete set of central estimates");
+        expect(rendered.text()).not.to.contain("with filename \"file.csv\"");
     });
 
 


### PR DESCRIPTION
We don't have the filename stored for old estimate sets. We shouldn't show the filename messages when the filename is null.