### PR TITLE
fix issues with form upload

### DIFF
--- a/app/src/main/contrib/actions/estimatesActionCreators.ts
+++ b/app/src/main/contrib/actions/estimatesActionCreators.ts
@@ -34,7 +34,6 @@ export const estimatesActionCreators = {
             if (newSetUrl) {
                 const setId = newSetUrl.split("/").filter(Number).pop();
                 dispatch(estimatesActionCreators.getUploadToken(setId));
-                dispatch(responsibilitiesActionCreators.refreshResponsibilities());
                 dispatch({
                     type: EstimateTypes.SET_CREATED,
                     data: setId
@@ -64,10 +63,11 @@ export const estimatesActionCreators = {
                 data: true
             } as PopulatingEstimateSet);
 
-            const ids = mapStateToPropsHelper.getResponsibilityIds(getState());
+            const state = getState();
+            const ids = mapStateToPropsHelper.getResponsibilityIds(state);
 
             const result = await (new EstimatesService(dispatch, getState))
-                .populateEstimatesFromFile(ids.groupId, ids.touchstoneId, ids.scenarioId, ids.estimateSetId, uploadToken);
+                .populateEstimatesFromFile(ids.groupId, ids.touchstoneId, ids.scenarioId, state.estimates.populatingSetId, uploadToken);
 
             dispatch(this._estimateSetPopulated(result));
             dispatch(responsibilitiesActionCreators.refreshResponsibilities())

--- a/app/src/main/contrib/components/Responsibilities/BurdenEstimates/UploadBurdenEstimatesForm.tsx
+++ b/app/src/main/contrib/components/Responsibilities/BurdenEstimates/UploadBurdenEstimatesForm.tsx
@@ -141,7 +141,6 @@ export class UploadEstimatesFormComponent extends React.Component<UploadEstimate
 
         this.uploadClient.on('fileSuccess', () => {
             this.resetUploadState(false);
-            this.props.createBurdenEstimateSet(this.state.metadata);
             this.props.populateEstimateSet(this.props.uploadToken);
         });
 
@@ -157,14 +156,20 @@ export class UploadEstimatesFormComponent extends React.Component<UploadEstimate
             this.setState({
                 uploadErrors: uploadErrors,
                 isUploading: false,
-                progress: 0
+                progress: 0,
+                file: null
             });
         });
     };
 
     componentDidUpdate(prevProps: Readonly<UploadEstimatesProps>) {
-        if (prevProps.url == null && this.props.url != null) {
-            this.uploadClient.upload();
+        if (prevProps.url != this.props.url && this.props.url != null) {
+            if (this.uploadClient.files[0].progress(false) == 1){
+                this.uploadClient.files[0].retry();
+            }
+            else {
+                this.uploadClient.upload();
+            }
         }
     }
 

--- a/app/src/main/contrib/components/Responsibilities/BurdenEstimates/UploadBurdenEstimatesForm.tsx
+++ b/app/src/main/contrib/components/Responsibilities/BurdenEstimates/UploadBurdenEstimatesForm.tsx
@@ -14,7 +14,7 @@ import {ContribAppState} from "../../../reducers/contribAppReducers";
 import {Dispatch} from "redux";
 import {estimatesActionCreators} from "../../../actions/estimatesActionCreators";
 import {connect} from "react-redux";
-import {branch, compose, renderComponent} from "recompose";
+import {branch, compose} from "recompose";
 import {LoadingElement} from "../../../../shared/partials/LoadingElement/LoadingElement";
 import {roundToOneDecimalPlace} from "../../../../shared/Helpers";
 import {OptionSelector} from "../../OptionSelector/OptionSelector";

--- a/app/src/main/contrib/reducers/estimatesReducer.ts
+++ b/app/src/main/contrib/reducers/estimatesReducer.ts
@@ -67,7 +67,8 @@ export const estimatesReducer = (state = estimatesInitialState, action: Estimate
                 hasPopulateSuccess: false,
                 populateErrors: [],
                 populatingSetId: null,
-                uploadToken: null
+                uploadToken: null,
+                populatingInProgress: false
             };
         case EstimateTypes.POPULATING_ESTIMATES:
             return {

--- a/app/src/test/contrib/actions/EstimatesActionsTests.ts
+++ b/app/src/test/contrib/actions/EstimatesActionsTests.ts
@@ -8,7 +8,6 @@ import {createMockContribStore} from "../../mocks/mockStore";
 import {mapStateToPropsHelper} from "../../../main/contrib/helpers/mapStateToPropsHelper";
 import {mockModellingGroup, mockResponsibilitySetWithExpectations, mockTouchstone} from "../../mocks/mockModels";
 import {ExtendedResponsibilitySet} from "../../../main/contrib/models/ResponsibilitySet";
-import {ResponsibilitiesTypes} from "../../../main/contrib/actionTypes/ResponsibilitiesTypes";
 import {BurdenEstimateSetType, ErrorInfo} from "../../../main/shared/models/Generated";
 import {BurdenOutcome, EstimateTypes} from "../../../main/contrib/actionTypes/EstimateTypes";
 import {responsibilitiesActionCreators} from "../../../main/contrib/actions/responsibilitiesActionCreators";
@@ -16,6 +15,7 @@ import {responsibilitiesActionCreators} from "../../../main/contrib/actions/resp
 describe("Estimates actions tests", () => {
     const sandbox = new Sandbox();
 
+    const testPopulatingSetId = 123;
     const testTouchstone = mockTouchstone();
     const testTouchstoneVersion = testTouchstone.versions[0];
     const testGroup = mockModellingGroup();
@@ -30,6 +30,9 @@ describe("Estimates actions tests", () => {
             responsibilities: {
                 currentResponsibility: testResponsibility,
                 responsibilitiesSet: testExtResponsibilitySet
+            },
+            estimates: {
+                populatingSetId: testPopulatingSetId
             }
         });
     };
@@ -87,14 +90,8 @@ describe("Estimates actions tests", () => {
             return Promise.resolve("TOKEN");
         });
 
-        sandbox.setStubFunc(ResponsibilitiesService.prototype, "clearCacheForResponsibilities", () => {
-            return Promise.resolve();
-        });
-        sandbox.setStubFunc(ResponsibilitiesService.prototype, "getResponsibilities", () => {
-            return Promise.resolve(testResponsibilitySet);
-        });
         sandbox.setStubFunc(mapStateToPropsHelper, "getResponsibilityIds", () => {
-            return {groupId: "g-1", touchstoneId: "t-1", scenarioId: "s-1", estimateSetId: "e-1"};
+            return {groupId: "g-1", touchstoneId: "t-1", scenarioId: "s-1"};
         });
 
         const data: BurdenEstimateSetType = {
@@ -108,9 +105,7 @@ describe("Estimates actions tests", () => {
             const actions = store.getActions();
             const expectedPayload = [
                 {type: EstimateTypes.SET_CREATED, data: "1"},
-                {type: EstimateTypes.UPLOAD_TOKEN_FETCHED, data: "TOKEN"},
-                {type: ResponsibilitiesTypes.SET_RESPONSIBILITIES, data: testExtResponsibilitySet},
-                {type: ResponsibilitiesTypes.SET_CURRENT_RESPONSIBILITY, data: testResponsibility}
+                {type: EstimateTypes.UPLOAD_TOKEN_FETCHED, data: "TOKEN"}
             ];
             expect(actions).to.eql(expectedPayload);
             expect(createBurdenEndpoint.calledOnce).to.be.true;
@@ -125,7 +120,7 @@ describe("Estimates actions tests", () => {
             const store = createStore();
 
             sandbox.setStubFunc(mapStateToPropsHelper, "getResponsibilityIds", () => {
-                return {groupId: "g-1", touchstoneId: "t-1", scenarioId: "s-1", estimateSetId: "e-1"};
+                return {groupId: "g-1", touchstoneId: "t-1", scenarioId: "s-1"};
             });
 
             sandbox.setStubFunc(EstimatesService.prototype, "populateEstimatesFromFile", () => {
@@ -157,7 +152,7 @@ describe("Estimates actions tests", () => {
             const store = createStore();
 
             sandbox.setStubFunc(mapStateToPropsHelper, "getResponsibilityIds", () => {
-                return {groupId: "g-1", touchstoneId: "t-1", scenarioId: "s-1", estimateSetId: "e-1"};
+                return {groupId: "g-1", touchstoneId: "t-1", scenarioId: "s-1"};
             });
             sandbox.setStubFunc(EstimatesService.prototype, "populateEstimatesFromFile", () => {
                 return Promise.resolve({status: "failure", errors: [{code: "missing-rows", message: "TEST"}]});
@@ -188,7 +183,7 @@ describe("Estimates actions tests", () => {
             const store = createStore();
 
             sandbox.setStubFunc(mapStateToPropsHelper, "getResponsibilityIds", () => {
-                return {groupId: "g-1", touchstoneId: "t-1", scenarioId: "s-1", estimateSetId: "e-1"};
+                return {groupId: "g-1", touchstoneId: "t-1", scenarioId: "s-1"};
             });
             sandbox.setStubFunc(EstimatesService.prototype, "populateEstimatesFromFile", () => {
                 return Promise.resolve({status: "failure", errors: [{code: "e-code", message: "TEST"}]});
@@ -219,7 +214,7 @@ describe("Estimates actions tests", () => {
             const store = createStore();
 
             sandbox.setStubFunc(mapStateToPropsHelper, "getResponsibilityIds", () => {
-                return {groupId: "g-1", touchstoneId: "t-1", scenarioId: "s-1", estimateSetId: "e-1"};
+                return {groupId: "g-1", touchstoneId: "t-1", scenarioId: "s-1"};
             });
             sandbox.setStubFunc(EstimatesService.prototype, "populateEstimatesFromFile", () => {
                 return Promise.resolve({status: "failure", errors: [{code: "e-code", message: "TEST"}]});
@@ -242,7 +237,7 @@ describe("Estimates actions tests", () => {
             const store = createStore();
 
             sandbox.setStubFunc(mapStateToPropsHelper, "getResponsibilityIds", () => {
-                return {groupId: "g-1", touchstoneId: "t-1", scenarioId: "s-1", estimateSetId: "e-1"};
+                return {groupId: "g-1", touchstoneId: "t-1", scenarioId: "s-1"};
             });
             sandbox.setStubFunc(EstimatesService.prototype, "getUploadToken", () => {
                 return Promise.resolve("TOKEN");

--- a/app/src/test/contrib/components/Responsibilities/BurdenEstimates/UploadEstimateFormComponentTests.tsx
+++ b/app/src/test/contrib/components/Responsibilities/BurdenEstimates/UploadEstimateFormComponentTests.tsx
@@ -10,7 +10,7 @@ import {
 } from "../../../../../main/contrib/components/Responsibilities/BurdenEstimates/UploadBurdenEstimatesForm";
 import {mount, shallow} from "enzyme";
 import {EventEmitter} from "events";
-import {Alert, Button} from "reactstrap";
+import {Alert} from "reactstrap";
 
 import {LoadingElement} from "../../../../../main/shared/partials/LoadingElement/LoadingElement";
 
@@ -21,6 +21,13 @@ describe("Upload Burden Estimates Form Component tests", () => {
     class FakeUploadClient extends EventEmitter {
         cancelled: boolean;
         uploadStarted: boolean;
+        retryStarted: boolean;
+        files: [{ progress: () => number, retry: () => void, retryStarted: boolean }] = [{
+            progress: () => 0, retry: () => {
+                this.retryStarted = true
+            },
+            retryStarted: false
+        }];
 
         assignBrowse() {
 
@@ -36,6 +43,10 @@ describe("Upload Burden Estimates Form Component tests", () => {
 
         upload() {
             this.uploadStarted = true
+        }
+
+        retry() {
+            this.retryStarted = true
         }
     }
 
@@ -60,7 +71,7 @@ describe("Upload Burden Estimates Form Component tests", () => {
             hasPopulateSuccess={props.hasPopulateSuccess || false}
             populateErrors={[]}
             resetPopulateState={props.resetPopulateState || nullFunction}
-            url={props.url != undefined ? "/url": props.url}
+            url={props.url != undefined ? "/url" : props.url}
             uploadToken={"TOKEN"}
             populatingInProgress={props.populatingInProgress || false}
             touchstoneId={"1"}
@@ -195,8 +206,7 @@ describe("Upload Burden Estimates Form Component tests", () => {
         expect(fakeUploadClient.uploadStarted).not.to.be.true;
     });
 
-
-    it("uploads estimates when url becomes not null", () => {
+    it("uploads estimates when url changes", () => {
 
         const resetPopulateState = sandbox.sinon.stub();
         const createEstimateSet = sandbox.sinon.stub();
@@ -220,6 +230,35 @@ describe("Upload Burden Estimates Form Component tests", () => {
         result.update();
 
         expect(fakeUploadClient.uploadStarted).to.be.true;
+    });
+
+    it("retries upload when url changes if file is unchanged", () => {
+
+        // when file has already been uploaded, its progress will be stored in the upload client as 1
+        fakeUploadClient.files[0].progress = () => 1;
+
+        const resetPopulateState = sandbox.sinon.stub();
+        const createEstimateSet = sandbox.sinon.stub();
+        const result = getComponent({
+            resetPopulateState: resetPopulateState,
+            createEstimateSet: createEstimateSet,
+            url: null
+        });
+        result.setState({
+            metadata: {
+                type: "central-averaged",
+                details: "whatever"
+            },
+            file: {fileName: "test.csv"}
+        });
+        result.find(".submit").simulate("click");
+        expect(resetPopulateState.called).to.be.true;
+        expect(createEstimateSet.called).to.be.true;
+
+        result.setProps({url: "URL"});
+        result.update();
+
+        expect(fakeUploadClient.files[0].retryStarted).to.be.true;
     });
 
     it("shows progress bar on file upload progress", () => {

--- a/app/src/test/contrib/components/Responsibilities/BurdenEstimates/UploadEstimateFormComponentTests.tsx
+++ b/app/src/test/contrib/components/Responsibilities/BurdenEstimates/UploadEstimateFormComponentTests.tsx
@@ -22,11 +22,10 @@ describe("Upload Burden Estimates Form Component tests", () => {
         cancelled: boolean;
         uploadStarted: boolean;
         retryStarted: boolean;
-        files: [{ progress: () => number, retry: () => void, retryStarted: boolean }] = [{
+        files: [{ progress: () => number, retry: () => void }] = [{
             progress: () => 0, retry: () => {
                 this.retryStarted = true
-            },
-            retryStarted: false
+            }
         }];
 
         assignBrowse() {
@@ -258,7 +257,7 @@ describe("Upload Burden Estimates Form Component tests", () => {
         result.setProps({url: "URL"});
         result.update();
 
-        expect(fakeUploadClient.files[0].retryStarted).to.be.true;
+        expect(fakeUploadClient.retryStarted).to.be.true;
     });
 
     it("shows progress bar on file upload progress", () => {

--- a/app/src/test/contrib/components/Responsibilities/BurdenEstimates/UploadEstimateFormTests.tsx
+++ b/app/src/test/contrib/components/Responsibilities/BurdenEstimates/UploadEstimateFormTests.tsx
@@ -1,18 +1,15 @@
 import * as React from "react";
 import {expect} from "chai";
-import {mount} from "enzyme";
 
 import "../../../../helper";
 import {
     mapDispatchToProps,
-    mapStateToProps,
-    UploadEstimatesForm
+    mapStateToProps
 } from "../../../../../main/contrib/components/Responsibilities/BurdenEstimates/UploadBurdenEstimatesForm";
 import {mockContribState} from "../../../../mocks/mockStates";
 import {Sandbox} from "../../../../Sandbox";
 import {estimatesActionCreators} from "../../../../../main/contrib/actions/estimatesActionCreators";
-import {LoadingElement} from "../../../../../main/shared/partials/LoadingElement/LoadingElement";
-import {createMockContribStore} from "../../../../mocks/mockStore";
+
 
 describe("Upload Burden Estimates Form tests", () => {
 


### PR DESCRIPTION
This fixes the following bug:
1. upload a file through the burden estimate upload form
2. change the metadata (or do nothing) and hit upload again without changing the file
3. upload button gets greyed out but nothing happens