### PR TITLE
VIMC-3254 hide wide format

### DIFF
--- a/app/src/@types/Settings.d.ts
+++ b/app/src/@types/Settings.d.ts
@@ -14,6 +14,7 @@ interface Settings {
     contrib: ContribSettings;
     test: AppSpecificSettings;
     showTouchstoneCreation: boolean;
+    hideWideFormat: (disease: string) => boolean;
     canDownloadEstimates: (groupId: string) => boolean;
 }
 

--- a/app/src/main/contrib/components/Responsibilities/Coverage/DownloadCoverageContent.tsx
+++ b/app/src/main/contrib/components/Responsibilities/Coverage/DownloadCoverageContent.tsx
@@ -13,6 +13,7 @@ import {coverageActionCreators} from "../../../actions/coverageActionCreators";
 import {withConfidentialityAgreement} from "../Overview/ConfidentialityAgreement";
 import {FileDownloadButton} from "../../../../shared/components/FileDownloadLink";
 import {UncontrolledTooltip} from "reactstrap";
+import {settings} from "../../../../shared/Settings";
 
 export interface DownloadCoverageContentProps {
     group: ModellingGroup;
@@ -53,6 +54,7 @@ export class DownloadCoverageContentComponent extends React.Component<DownloadCo
         const url = `/modelling-groups/${group.id}/responsibilities/${touchstone.id}/${scenario.id}/coverage/csv/`
             + `?format=${selectedFormat}&all-countries=${!this.state.filterToExpectations}`;
 
+        const showWideFormat = !settings.hideWideFormat(this.props.scenario.disease);
         return <div>
             <p>
                 Each scenario is based on vaccination coverage from up to 3 different
@@ -96,13 +98,15 @@ export class DownloadCoverageContentComponent extends React.Component<DownloadCo
                     <CoverageSetList coverageSets={this.props.coverageSets}/>
                 </div>
             </div>
-            <div className="row mt-4">
+            {showWideFormat && <div className="row mt-4">
                 <div className="col-12 col-md-6">
                     <div>
                         <span className="smallTitle">
                             Choose format
                         </span>
-                        <a href={"#"} id={"format-tooltip"} className={"ml-1 small"} onClick={(e)=> {e.preventDefault()}}>What's this?</a>
+                        <a href={"#"} id={"format-tooltip"} className={"ml-1 small"} onClick={(e) => {
+                            e.preventDefault()
+                        }}>What's this?</a>
                         <UncontrolledTooltip target="format-tooltip" className={"text-muted"}>
                             Wide format includes coverage and target values for all years in a single row. Long format
                             includes a row for each year.
@@ -127,17 +131,22 @@ export class DownloadCoverageContentComponent extends React.Component<DownloadCo
                     </table>
                 </div>
             </div>
+            }
             <div className="row mt-4">
                 <div className="col-12">
-                   <label className="checkbox-inline"><input type="checkbox"
-                                                             id={"filter-countries"}
-                                                             className={"mr-1"}
-                                                             onChange={this.toggleAllCountries}
-                                                             checked={this.state.filterToExpectations} />
-                       Filter to touchstone countries</label>
-                    <a href={"#"} id={"countries-tooltip"} className={"ml-1 small"} onClick={(e)=> {e.preventDefault()}}>What's this?</a>
-                    <UncontrolledTooltip target="countries-tooltip" className={"text-muted"}>When this is checked we will only include coverage data for
-                        countries we expect burden estimates for in this touchstone. To include all the coverage data we have for this scenario, please de-select this option</UncontrolledTooltip>
+                    <label className="checkbox-inline"><input type="checkbox"
+                                                              id={"filter-countries"}
+                                                              className={"mr-1"}
+                                                              onChange={this.toggleAllCountries}
+                                                              checked={this.state.filterToExpectations}/>
+                        Filter to touchstone countries</label>
+                    <a href={"#"} id={"countries-tooltip"} className={"ml-1 small"} onClick={(e) => {
+                        e.preventDefault()
+                    }}>What's this?</a>
+                    <UncontrolledTooltip target="countries-tooltip" className={"text-muted"}>When this is checked we
+                        will only include coverage data for
+                        countries we expect burden estimates for in this touchstone. To include all the coverage data we
+                        have for this scenario, please de-select this option</UncontrolledTooltip>
                 </div>
             </div>
             <div className="mt-4">

--- a/app/src/main/shared/settings/default.ts
+++ b/app/src/main/shared/settings/default.ts
@@ -14,7 +14,9 @@ export const settings: Settings = {
         return !this.nonStochasticTouchstones.some((ts: string) => touchstoneId.indexOf(ts) === 0);
     },
     hideWideFormat: function (disease) {
-        return ["MenA", "JE", "YF", "HPV", "measles", "rubella"].indexOf(disease) > -1
+        return ["MenA", "JE", "YF", "HPV", "measles", "rubella"]
+            .map(d => d.toLocaleLowerCase())
+            .indexOf(disease.toLowerCase()) > -1
     },
     canDownloadEstimates: function (groupId) {
         return ["PHE-Vynnycky-WHO",

--- a/app/src/main/shared/settings/default.ts
+++ b/app/src/main/shared/settings/default.ts
@@ -13,6 +13,9 @@ export const settings: Settings = {
         //is touchstone id NOT a version of any name in array of non-stochastic touchstones
         return !this.nonStochasticTouchstones.some((ts: string) => touchstoneId.indexOf(ts) === 0);
     },
+    hideWideFormat: function (disease) {
+        return ["MenA", "JE", "YF", "HPV", "measles", "rubella"].indexOf(disease) > -1
+    },
     canDownloadEstimates: function (groupId) {
         return ["PHE-Vynnycky-WHO",
             "JHU-Lessler-WHO",

--- a/app/src/test/contrib/components/Responsibilities/Coverage/DownloadCoverageContentTests.tsx
+++ b/app/src/test/contrib/components/Responsibilities/Coverage/DownloadCoverageContentTests.tsx
@@ -130,6 +130,20 @@ describe("Download Coverage Content Component", () => {
         expect(onFormatSelectStub.called).to.equal(true);
     });
 
+    it("does not show format control for prohibited diseases", () => {
+
+        const rendered = shallow(<DownloadCoverageContentComponent
+            coverageSets={[testCoverageSet]}
+            group={testGroup}
+            scenario={{...testScenario, disease: "measles"}}
+            selectedFormat={"long"}
+            setFormat={() => {
+            }}
+            touchstone={testTouchstone}/>);
+
+        expect(rendered.find(FormatControl).length).to.equal(0);
+    });
+
     it("filterToExpectations is selected by default", () => {
         const rendered = shallow(<DownloadCoverageContent/>, {context: {store}}).dive().dive().dive()
             .dive().dive().dive();

--- a/app/src/test/shared/settingsTests.ts
+++ b/app/src/test/shared/settingsTests.ts
@@ -1,0 +1,10 @@
+import {expect} from "chai";
+import {settings} from "../../main/shared/Settings";
+
+describe("settings", () => {
+
+    it("disease matching is case insensitive", () => {
+        expect(settings.hideWideFormat("measles")).to.eq(true);
+        expect(settings.hideWideFormat("Measles")).to.eq(true);
+    })
+});


### PR DESCRIPTION
Wide format has a bug for campaign data, so we're hiding the format control for all diseases that have campaigns in the latest touchstone until this is fixed.