### PR TITLE
vimc-3209 bug when changing touchstones and downloading demographics

### DIFF
--- a/app/config/api_version
+++ b/app/config/api_version
@@ -1,1 +1,2 @@
-master
+vimc-3209
+

--- a/app/config/api_version
+++ b/app/config/api_version
@@ -1,2 +1,2 @@
-vimc-3209
+master
 

--- a/app/src/main/shared/actions/demographicActionCreators.ts
+++ b/app/src/main/shared/actions/demographicActionCreators.ts
@@ -12,6 +12,10 @@ export const demographicActionCreators = {
         return async (dispatch: Dispatch<ContribAppState | AdminAppState>, getState: () => ContribAppState | AdminAppState) => {
             const dataSets: DemographicDataset[] = await (new DemographicService(dispatch, getState))
                 .getDataSetsByTouchstoneVersionId(touchstoneVersionId);
+
+            // reset selected data set
+            await dispatch(demographicActionCreators.setDataSet(null));
+
             return dispatch({
                 type: DemographicTypes.DEMOGRAPHIC_DATA_SETS_FETCHED,
                 data: dataSets
@@ -21,8 +25,11 @@ export const demographicActionCreators = {
 
     setDataSet(dataSetId: string) {
         return (dispatch: Dispatch<ContribAppState>, getState: () => ContribAppState | AdminAppState) => {
-            const dataSets = getState().demographics.dataSets;
-            const dataSet = dataSets.find((set: DemographicDataset) => set.id === dataSetId);
+            let dataSet = null;
+            if (!!dataSetId){
+                const dataSets = getState().demographics.dataSets;
+                dataSet = dataSets.find((set: DemographicDataset) => set.id === dataSetId);
+            }
             return dispatch({
                 type: DemographicTypes.DEMOGRAPHIC_SET_DATA_SET,
                 data: dataSet

--- a/app/src/test/admin/actions/pages/DownloadDemographicPageActionsTests.ts
+++ b/app/src/test/admin/actions/pages/DownloadDemographicPageActionsTests.ts
@@ -7,6 +7,7 @@ import {downloadDemographicsAdminPageActionCreators} from "../../../../main/admi
 import {DemographicService} from "../../../../main/shared/services/DemographicService";
 import {mockDemographicDataset} from "../../../mocks/mockModels";
 import {touchstoneVersionPageActionCreators} from "../../../../main/admin/actions/pages/touchstoneVersionPageActionCreators";
+import {DemographicDataset} from "../../../../main/shared/models/Generated";
 
 describe("Download Demographic Admin Page actions tests", () => {
     const sandbox = new Sandbox();
@@ -42,8 +43,10 @@ describe("Download Demographic Admin Page actions tests", () => {
         const actions = store.getActions();
 
         const expectedPayload = [
+            {type: DemographicTypes.DEMOGRAPHIC_SET_DATA_SET, data: null as DemographicDataset},
             {type: DemographicTypes.DEMOGRAPHIC_DATA_SETS_FETCHED, data: [testDemographicDataSet]}
         ];
+
         expect(actions).to.eql(expectedPayload);
     });
 

--- a/app/src/test/contrib/actions/pages/DownloadDemographicPageActionsTests.ts
+++ b/app/src/test/contrib/actions/pages/DownloadDemographicPageActionsTests.ts
@@ -8,6 +8,7 @@ import {responsibilityOverviewPageActionCreators} from "../../../../main/contrib
 import {mockContribState} from "../../../mocks/mockStates";
 import {downloadDemographicsContribPageActionCreators} from "../../../../main/contrib/actions/pages/downloadDemographicsContribPageActionCreators";
 import {DemographicTypes} from "../../../../main/shared/actionTypes/DemographicTypes";
+import {DemographicDataset} from "../../../../main/shared/models/Generated";
 
 describe("Download Demographic Contrib Page actions tests", () => {
     const sandbox = new Sandbox();
@@ -42,6 +43,7 @@ describe("Download Demographic Contrib Page actions tests", () => {
         const actions = store.getActions();
 
         const expectedPayload = [
+            {type: DemographicTypes.DEMOGRAPHIC_SET_DATA_SET, data: null as DemographicDataset},
             {type: DemographicTypes.DEMOGRAPHIC_DATA_SETS_FETCHED, data: [testDemographicDataSet]}
         ];
         expect(actions).to.eql(expectedPayload);

--- a/app/src/test/shared/actions/DemographicActionsTests.ts
+++ b/app/src/test/shared/actions/DemographicActionsTests.ts
@@ -6,6 +6,7 @@ import {DemographicService} from "../../../main/shared/services/DemographicServi
 import {createMockContribStore} from "../../mocks/mockStore";
 import {mockDemographicDataset} from "../../mocks/mockModels";
 import {DemographicTypes} from "../../../main/shared/actionTypes/DemographicTypes";
+import {DemographicDataset} from "../../../main/shared/models/Generated";
 
 describe("Demographic actions tests", () => {
     const sandbox = new Sandbox();
@@ -16,19 +17,25 @@ describe("Demographic actions tests", () => {
         sandbox.restore();
     });
 
-    it("sets fetched sets", (done) => {
+    it("resets selected data set and sets fetched sets", (done) => {
         const store = createMockContribStore({});
         sandbox.setStubFunc(DemographicService.prototype, "getDataSetsByTouchstoneVersionId", () => {
             return Promise.resolve([testDemographicDataSet]);
         });
-        store.dispatch(demographicActionCreators.getDataSets('touchstone-1'))
+        store.dispatch(demographicActionCreators.getDataSets('touchstone-1'));
         setTimeout(() => {
-            const actions = store.getActions()
-            const expectedPayload = {
-                type: DemographicTypes.DEMOGRAPHIC_DATA_SETS_FETCHED,
-                data: [testDemographicDataSet]
-            }
-            expect(actions).to.eql([expectedPayload])
+            const actions = store.getActions();
+            const expectedPayloads = [
+                {
+                    type: DemographicTypes.DEMOGRAPHIC_SET_DATA_SET,
+                    data: null as DemographicDataset
+                },
+                {
+                    type: DemographicTypes.DEMOGRAPHIC_DATA_SETS_FETCHED,
+                    data: [testDemographicDataSet]
+                }
+            ];
+            expect(actions).to.eql(expectedPayloads);
             done();
         });
     });
@@ -39,6 +46,17 @@ describe("Demographic actions tests", () => {
         setTimeout(() => {
             const actions = store.getActions()
             const expectedPayload = {type: DemographicTypes.DEMOGRAPHIC_SET_DATA_SET, data: testDemographicDataSet}
+            expect(actions).to.eql([expectedPayload])
+            done();
+        });
+    });
+
+    it("can set data set to null", (done) => {
+        const store = createMockContribStore({demographics: {dataSets: [testDemographicDataSet]}});
+        store.dispatch(demographicActionCreators.setDataSet(null))
+        setTimeout(() => {
+            const actions = store.getActions()
+            const expectedPayload = {type: DemographicTypes.DEMOGRAPHIC_SET_DATA_SET, data: null as DemographicDataset}
             expect(actions).to.eql([expectedPayload])
             done();
         });


### PR DESCRIPTION
Reported by Wes: https://mrc-ide.myjetbrains.com/youtrack/issue/VIMC-3209

Problem was the selected data set wasn't being updated when the touchstone changed, so would have a dataset belonging to the wrong touchstone selected.