### PR TITLE
VIMC-4119 update integration tests after breaking db change

### DIFF
--- a/app/src/integrationTests/AdminIntegrationTests.tsx
+++ b/app/src/integrationTests/AdminIntegrationTests.tsx
@@ -398,7 +398,7 @@ function addResponsibilities(db: Client) {
             BEGIN
                 INSERT INTO scenario_type (id, name)
                 VALUES ('default', 'default');
-                INSERT INTO scenario_description (id, description, disease, type)
+                INSERT INTO scenario_description (id, description, disease, scenario_type)
                 VALUES ('${scenarioId}', 'Yellow Fever scenario', 'yf', 'default');
                 INSERT INTO scenario (touchstone, scenario_description)
                 VALUES ('${touchstoneVersionId}', '${scenarioId}')

--- a/app/src/integrationTests/AdminIntegrationTests.tsx
+++ b/app/src/integrationTests/AdminIntegrationTests.tsx
@@ -396,8 +396,10 @@ function addResponsibilities(db: Client) {
                 DECLARE set_id integer;
                 DECLARE burden_estimate_expectation_id integer;
             BEGIN
-                INSERT INTO scenario_description (id, description, disease)
-                VALUES ('${scenarioId}', 'Yellow Fever scenario', 'yf');
+                INSERT INTO scenario_type (id, name)
+                VALUES ('default', 'default');
+                INSERT INTO scenario_description (id, description, disease, type)
+                VALUES ('${scenarioId}', 'Yellow Fever scenario', 'yf', 'default');
                 INSERT INTO scenario (touchstone, scenario_description)
                 VALUES ('${touchstoneVersionId}', '${scenarioId}')
                 RETURNING id INTO scenario_id;

--- a/app/src/integrationTests/IntegrationTest.ts
+++ b/app/src/integrationTests/IntegrationTest.ts
@@ -108,8 +108,9 @@ export function addScenario(db:Client, scenarioId: String, touchstoneVersionId: 
             DO $$
             BEGIN
                 INSERT INTO disease (id, name) VALUES ('yf', 'Yellow Fever');
-                INSERT INTO scenario_description (id, description, disease)
-                VALUES ('${scenarioId}', 'Yellow Fever scenario', 'yf');
+                INSERT INTO scenario_type (id, name) VALUES ('default', 'default');
+                INSERT INTO scenario_description (id, description, disease, scenario_type)
+                VALUES ('${scenarioId}', 'Yellow Fever scenario', 'yf', 'default');
                 INSERT INTO scenario (touchstone, scenario_description)
                 VALUES ('${touchstoneVersionId}', '${scenarioId}');       
             END $$;


### PR DESCRIPTION
Same issue as with the API - integration tests failing since [this db change](https://github.com/vimc/montagu-db/commit/732ae2e021a6bab16c85195aa432cf1cd2588df5)