### PR TITLE
vimc-4150 trap exit and clean up containers

### DIFF
--- a/buildkite/pipeline.yml
+++ b/buildkite/pipeline.yml
@@ -9,9 +9,3 @@ steps:
 
   - label: ":construction_worker: Build and push integration test image"
     command: buildkite/make-integration-tests-image.sh
-
-  - wait
-
-  - label: ":hammer: Stop dependencies"
-    command: app/scripts/clear-docker.sh
-    allow_dependency_failure: true

--- a/buildkite/run-build.sh
+++ b/buildkite/run-build.sh
@@ -5,6 +5,12 @@ HERE=$(dirname $0)
 
 PORTAL_BUILD_ENV=montagu-portal-build-env:$GIT_SHA
 
+# Clean up docker containers on exit
+trap on_exit EXIT
+function on_exit() {
+    ./$HERE/../app/scripts/clear-docker.sh
+}
+
 ./$HERE/../app/scripts/run-dependencies.sh
 ./$HERE/../app/scripts/add-test-accounts-for-integration-tests.sh
 


### PR DESCRIPTION
Docker containers brought up during the build should be removed in the same step, when the script for that build step exits.