### PR TITLE
vimc-4240 Exclude MONTAGU_TASK_QUEUE user from the user management page

### DIFF
--- a/app/src/main/admin/actions/usersActionCreators.ts
+++ b/app/src/main/admin/actions/usersActionCreators.ts
@@ -23,7 +23,8 @@ export const usersActionCreators = {
 
     getAllUsers() {
         return async (dispatch: Dispatch<AdminAppState>, getState: () => AdminAppState) => {
-            const users: User[] = await (new UsersService(dispatch, getState)).getAllUsers();
+            const allUsers: User[] = await (new UsersService(dispatch, getState)).getAllUsers();
+            const users = allUsers.filter(u => u.username !== "MONTAGU_TASK_QUEUE");
             dispatch({
                 type: UsersTypes.ALL_USERS_FETCHED,
                 data: users

--- a/app/src/test/admin/actions/UsersActionsTests.ts
+++ b/app/src/test/admin/actions/UsersActionsTests.ts
@@ -66,7 +66,7 @@ describe("Admin Users actions tests", () => {
         store.dispatch(usersActionCreators.getAllUsers());
         setTimeout(() => {
             const actions = store.getActions();
-            const expectedPayload = {type: UsersTypes.ALL_USERS_FETCHED, data: [testUser2, testUser1]};
+            const expectedPayload = {type: UsersTypes.ALL_USERS_FETCHED, data: [testUser2, testUser]};
             expect(actions).toEqual([expectedPayload]);
             done();
         });

--- a/app/src/test/admin/actions/UsersActionsTests.ts
+++ b/app/src/test/admin/actions/UsersActionsTests.ts
@@ -59,7 +59,7 @@ describe("Admin Users actions tests", () => {
 
     it("get all users excludes system task queue user", (done) => {
         sandbox.setStubFunc(UsersService.prototype, "getAllUsers", () => {
-            const tqUser = mockUser({username: "MOCK_TASK_QUEUE"});
+            const tqUser = mockUser({username: "MONTAGU_TASK_QUEUE"});
             return Promise.resolve([testUser2, tqUser, testUser]);
         });
 

--- a/app/src/test/admin/actions/UsersActionsTests.ts
+++ b/app/src/test/admin/actions/UsersActionsTests.ts
@@ -57,6 +57,21 @@ describe("Admin Users actions tests", () => {
         });
     });
 
+    it("get all users excludes system task queue user", (done) => {
+        sandbox.setStubFunc(UsersService.prototype, "getAllUsers", () => {
+            const tqUser = mockUser({username: "MOCK_TASK_QUEUE"});
+            return Promise.resolve([testUser2, tqUser, testUser]);
+        });
+
+        store.dispatch(usersActionCreators.getAllUsers());
+        setTimeout(() => {
+            const actions = store.getActions();
+            const expectedPayload = {type: UsersTypes.ALL_USERS_FETCHED, data: [testUser2, testUser1]};
+            expect(actions).toEqual([expectedPayload]);
+            done();
+        });
+    });
+
     it("gets global roles", (done) => {
 
         sandbox.setStubFunc(UsersService.prototype, "getGlobalRoles", () => {


### PR DESCRIPTION
Could have done in this in the api, but I figured it was valid to return this system user, we just don't want it being viewable in the portal. 