### PR TITLE
vimc-4325 don't show finished touchstones in active touchstone list

### DIFF
--- a/app/src/main/admin/components/Touchstones/List/TouchstoneList.tsx
+++ b/app/src/main/admin/components/Touchstones/List/TouchstoneList.tsx
@@ -16,7 +16,7 @@ export const TouchstoneListComponent: React.FunctionComponent<TouchstoneListProp
         <div className="mb-5 row">
             <div className="col-12">
                 <h4>Active touchstones</h4>
-                <div className="mb-2">The latest version of these touchstones is 'open' or 'in-preparation'.</div>
+                <div className="mb-2">These touchstones have at least one version that is 'open' or 'in-preparation'.</div>
                 <TouchstoneTable touchstones={props.active} showFinished={false}/>
             </div>
         </div>

--- a/app/src/main/admin/components/Touchstones/List/TouchstoneList.tsx
+++ b/app/src/main/admin/components/Touchstones/List/TouchstoneList.tsx
@@ -17,14 +17,14 @@ export const TouchstoneListComponent: React.FunctionComponent<TouchstoneListProp
             <div className="col-12">
                 <h4>Active touchstones</h4>
                 <div className="mb-2">The latest version of these touchstones is 'open' or 'in-preparation'.</div>
-                <TouchstoneTable touchstones={props.active}/>
+                <TouchstoneTable touchstones={props.active} showFinished={false}/>
             </div>
         </div>
         <div className="mb-5 row">
             <div className="col-12">
                 <h4>Inactive touchstones</h4>
                 <div className="mb-2">All versions of these touchstones are 'finished'.</div>
-                <TouchstoneTable touchstones={props.inactive}/>
+                <TouchstoneTable touchstones={props.inactive} showFinished={true}/>
             </div>
         </div>
     </div>;

--- a/app/src/main/admin/components/Touchstones/List/TouchstoneListItem.tsx
+++ b/app/src/main/admin/components/Touchstones/List/TouchstoneListItem.tsx
@@ -2,23 +2,27 @@ import * as React from "react";
 import {InternalLink} from "../../../../shared/components/InternalLink";
 import {Touchstone} from "../../../../shared/models/Generated";
 
-export class TouchstoneListItem extends React.Component<Touchstone, undefined> {
-    render() {
-
-        const touchstoneUrl = `/touchstones/${this.props.id}/`;
-
-        let latestVersionUrl = "", latestVersionId = "";
-        if (this.props.versions.length > 0) {
-            // The API is guaranteed to return versions in descending order
-            latestVersionId = this.props.versions[0].id;
-            latestVersionUrl = `/touchstones/${this.props.id}/${latestVersionId}/`;
-        }
-
-        return <tr>
-            <td>{this.props.id}</td>
-            <td><InternalLink href={touchstoneUrl}>{this.props.description}</InternalLink></td>
-            <td>{this.props.comment}</td>
-            <td>{latestVersionId && <InternalLink href={latestVersionUrl}>{latestVersionId}</InternalLink>}</td>
-        </tr>;
-    }
+export interface TouchstoneListItemProps extends Touchstone {
+    showFinished: boolean;
 }
+
+export const TouchstoneListItem: React.FunctionComponent<TouchstoneListItemProps> = (props: TouchstoneListItemProps) => {
+
+    const touchstoneUrl = `/touchstones/${props.id}/`;
+
+    let latestVersionUrl = "", latestVersionId = "";
+    const versionsToChooseFrom = props.versions.filter(v => v.status != "finished" || props.showFinished);
+    if (versionsToChooseFrom.length > 0) {
+        // The API is guaranteed to return versions in descending order
+        latestVersionId = versionsToChooseFrom[0].id;
+        latestVersionUrl = `/touchstones/${props.id}/${latestVersionId}/`;
+    }
+
+    return <tr>
+        <td>{props.id}</td>
+        <td><InternalLink href={touchstoneUrl}>{props.description}</InternalLink></td>
+        <td>{props.comment}</td>
+        <td>{latestVersionId && <InternalLink href={latestVersionUrl}>{latestVersionId}</InternalLink>}</td>
+    </tr>;
+
+};

--- a/app/src/main/admin/components/Touchstones/List/TouchstoneTable.tsx
+++ b/app/src/main/admin/components/Touchstones/List/TouchstoneTable.tsx
@@ -1,9 +1,11 @@
 import {Touchstone} from "../../../../shared/models/Generated";
 import * as React from "react";
 import {TouchstoneListItem} from "./TouchstoneListItem";
+import {shallow} from "enzyme";
 
 export interface TouchstoneTableProps {
     touchstones: Touchstone[];
+    showFinished: boolean;
 }
 
 export const TouchstoneTable: React.FunctionComponent<TouchstoneTableProps> = (props) => {
@@ -17,7 +19,7 @@ export const TouchstoneTable: React.FunctionComponent<TouchstoneTableProps> = (p
         </tr>
         </thead>
         <tbody>
-        {props.touchstones.map(t => <TouchstoneListItem key={t.id} {...t} />)}
+        {props.touchstones.map(t => <TouchstoneListItem showFinished={props.showFinished} key={t.id} {...t} />)}
         </tbody>
     </table>;
 };

--- a/app/src/main/admin/components/Touchstones/List/TouchstoneTable.tsx
+++ b/app/src/main/admin/components/Touchstones/List/TouchstoneTable.tsx
@@ -15,7 +15,7 @@ export const TouchstoneTable: React.FunctionComponent<TouchstoneTableProps> = (p
             <th>ID</th>
             <th>Description</th>
             <th>Comment</th>
-            <th>Latest version</th>
+            <th>{props.showFinished ? "Latest version" : "Latest unfinished version"}</th>
         </tr>
         </thead>
         <tbody>

--- a/app/src/test/admin/components/Touchstones/List/TouchstoneListItemTests.tsx
+++ b/app/src/test/admin/components/Touchstones/List/TouchstoneListItemTests.tsx
@@ -6,11 +6,13 @@ import * as React from "react";
 import {InternalLink} from "../../../../../main/shared/components/InternalLink";
 
 describe("TouchstoneListItem", () => {
+
+    const v1 = mockTouchstoneVersion({id: "v1", status: "finished"});
+    const v2 = mockTouchstoneVersion({id: "v2", status: "open"});
+    const t = mockTouchstone({id: "t1", description: "desc1"}, [v1, v2]);
+
     it("renders links to touchstone and first version page", () => {
-        const v1 = mockTouchstoneVersion({id: "v1"});
-        const v2 = mockTouchstoneVersion();
-        const t = mockTouchstone({id: "t1", description: "desc1"}, [v1, v2]);
-        const rendered = shallow(<TouchstoneListItem {...t}/>);
+        const rendered = shallow(<TouchstoneListItem showFinished={true} {...t}/>);
         const cells = rendered.find("td");
 
         expect(cells.length).toEqual(4);
@@ -27,7 +29,7 @@ describe("TouchstoneListItem", () => {
     it("latest version cell is empty where no versions exist yet", () => {
 
         const t = mockTouchstone({id: "t1", description: "desc1"}, []);
-        const rendered = shallow(<TouchstoneListItem {...t}/>);
+        const rendered = shallow(<TouchstoneListItem showFinished={true} {...t}/>);
         const cells = rendered.find("td");
 
         expect(cells.length).toEqual(4);
@@ -35,4 +37,29 @@ describe("TouchstoneListItem", () => {
         const latestVersionCell = cells.at(3);
         expect(latestVersionCell.find(InternalLink)).toHaveLength(0);
     });
+
+    it("shows latest un-finished version if showFinished=false", () => {
+
+        const rendered = shallow(<TouchstoneListItem showFinished={false} {...t}/>);
+        const cells = rendered.find("td");
+
+        expect(cells.length).toEqual(4);
+
+        const latestVersionCell = cells.at(3);
+        expect(latestVersionCell.find(InternalLink).dive().text()).toEqual(v2.id);
+        expect(latestVersionCell.find(InternalLink).prop("href")).toEqual("/touchstones/t1/v2/");
+    });
+
+    it("shows latest version with any status if showFinished=true", () => {
+
+        const rendered = shallow(<TouchstoneListItem showFinished={true} {...t}/>);
+        const cells = rendered.find("td");
+
+        expect(cells.length).toEqual(4);
+
+        const latestVersionCell = cells.at(3);
+        expect(latestVersionCell.find(InternalLink).dive().text()).toEqual(v1.id);
+        expect(latestVersionCell.find(InternalLink).prop("href")).toEqual("/touchstones/t1/v1/");
+    });
+
 });

--- a/app/src/test/admin/components/Touchstones/List/TouchstoneListTests.tsx
+++ b/app/src/test/admin/components/Touchstones/List/TouchstoneListTests.tsx
@@ -8,6 +8,7 @@ import {TouchstoneTable} from "../../../../../main/admin/components/Touchstones/
 
 
 describe("TouchstoneList (admin)", () => {
+
     it("touchstone with one open version is active", () => {
         checkThatTouchstoneIsActive(true, mockTouchstone({id: "active1"}, [
             mockTouchstoneVersion({status: "open"}),
@@ -39,10 +40,12 @@ describe("TouchstoneList (admin)", () => {
         const expectedSection = sections.at(isActive ? 0 : 1);
         const wrongSection = sections.at(isActive ? 1 : 0);
         expect(expectedSection.props()).toEqual({
-            touchstones: [touchstone]
+            touchstones: [touchstone],
+            showFinished: !isActive
         });
         expect(wrongSection.props()).toEqual({
-            touchstones: []
+            touchstones: [],
+            showFinished: isActive
         });
     }
 });

--- a/app/src/test/admin/components/Touchstones/List/TouchstoneTableTests.tsx
+++ b/app/src/test/admin/components/Touchstones/List/TouchstoneTableTests.tsx
@@ -14,4 +14,16 @@ describe("TouchstoneTable", () => {
         rendered = shallow(<TouchstoneTable showFinished={false} touchstones={[t]} />);
         expect(rendered.find(TouchstoneListItem).props()).toEqual({...t, showFinished: false});
     });
+
+    it("column header reads 'Latest version' if showFinished is true", () => {
+        const t = mockTouchstone();
+        let rendered = shallow(<TouchstoneTable showFinished={true} touchstones={[t]} />);
+        expect(rendered.find("th").at(3).text()).toBe("Latest version");
+    });
+
+    it("column header reads 'Latest unfinished version' if showFinished is true", () => {
+        const t = mockTouchstone();
+        let rendered = shallow(<TouchstoneTable showFinished={false} touchstones={[t]} />);
+        expect(rendered.find("th").at(3).text()).toBe("Latest unfinished version");
+    });
 });

--- a/app/src/test/admin/components/Touchstones/List/TouchstoneTableTests.tsx
+++ b/app/src/test/admin/components/Touchstones/List/TouchstoneTableTests.tsx
@@ -1,0 +1,17 @@
+import {shallow} from "enzyme";
+import * as React from "react";
+import {TouchstoneTable} from "../../../../../main/admin/components/Touchstones/List/TouchstoneTable";
+import {mockTouchstone} from "../../../../mocks/mockModels";
+import {TouchstoneListItem} from "../../../../../main/admin/components/Touchstones/List/TouchstoneListItem";
+
+describe("TouchstoneTable", () => {
+
+    it("passes showFinished prop to list items", () => {
+        const t = mockTouchstone();
+        let rendered = shallow(<TouchstoneTable showFinished={true} touchstones={[t]} />);
+        expect(rendered.find(TouchstoneListItem).props()).toEqual({...t, showFinished: true});
+
+        rendered = shallow(<TouchstoneTable showFinished={false} touchstones={[t]} />);
+        expect(rendered.find(TouchstoneListItem).props()).toEqual({...t, showFinished: false});
+    });
+});


### PR DESCRIPTION
It's possible for a touchstone to have a previous version in un-finished status even though the most recent version is marked as "finished", e.g.
https://montagu.vaccineimpact.org/admin/touchstones/201907wue/

In this case the latest, finished, version should not be linked in the table of "active" touchstones: 
https://montagu.vaccineimpact.org/admin/touchstones/

nb: some of these cases are probably in error, we should also pick up this ticket to allow admins to easily mark touchstones as finished: https://mrc-ide.myjetbrains.com/youtrack/issue/VIMC-10