### PR TITLE
vimc-4433 Restrict coverage route to users with coverage-write permission

### DIFF
--- a/app/src/main/admin/components/AdminApp.tsx
+++ b/app/src/main/admin/components/AdminApp.tsx
@@ -8,7 +8,7 @@ import {AppProps, mapStateToAppProps} from "../../shared/components/App";
 export class AdminAppComponent extends React.Component<AppProps, undefined> {
     render() {
         return <div>
-            <AdminRouter loggedIn={ this.props.loggedIn } history={this.props.history} permissions={this.props.permissions} />
+            <AdminRouter history={this.props.history} />
             <NotificationArea />
             <ErrorLog />
         </div>;

--- a/app/src/main/admin/components/AdminApp.tsx
+++ b/app/src/main/admin/components/AdminApp.tsx
@@ -8,7 +8,7 @@ import {AppProps, mapStateToAppProps} from "../../shared/components/App";
 export class AdminAppComponent extends React.Component<AppProps, undefined> {
     render() {
         return <div>
-            <AdminRouter loggedIn={ this.props.loggedIn } history={this.props.history} />
+            <AdminRouter loggedIn={ this.props.loggedIn } history={this.props.history} permissions={this.props.permissions} />
             <NotificationArea />
             <ErrorLog />
         </div>;

--- a/app/src/main/admin/components/AdminApp.tsx
+++ b/app/src/main/admin/components/AdminApp.tsx
@@ -4,8 +4,9 @@ import {ErrorLog} from "../../shared/components/ErrorLog/ErrorLog";
 import {AdminRouter} from "./AdminRouter";
 import {NotificationArea} from "../../shared/components/NotificationArea/NotificationArea";
 import {AppProps, mapStateToAppProps} from "../../shared/components/App";
+import {AdminAppState} from "../reducers/adminAppReducers";
 
-export class AdminAppComponent extends React.Component<AppProps, undefined> {
+export class AdminAppComponent extends React.Component<AppProps, AdminAppState> {
     render() {
         return <div>
             <AdminRouter history={this.props.history} />

--- a/app/src/main/admin/components/AdminRouter.tsx
+++ b/app/src/main/admin/components/AdminRouter.tsx
@@ -22,9 +22,12 @@ import {CoveragePage} from "./Touchstones/Coverage/CoveragePage";
 import {LoginPage} from "../../shared/components/LoginPage";
 import {ModelMetaPage} from "./ModellingGroups/Models/ModelMetaPage";
 import {CoverageVariablesPage} from "./Touchstones/Coverage/CoverageVariablesPage";
+import {AdminAppState} from "../reducers/adminAppReducers";
+import {UserDetailsProps} from "./Users/SingleUser/UserDetailsContent";
 
 interface AdminRouterProps {
     loggedIn: boolean;
+    permissions: string[];
     history: History;
 }
 
@@ -44,7 +47,9 @@ export const AdminRouter: React.FunctionComponent<AdminRouterProps> = (props: Ad
         <Route exact path="/touchstones/:touchstoneId/:touchstoneVersionId/demographics/"
                component={DownloadDemographicsAdminPage}/>
         <Route exact path="/touchstones/:touchstoneId/:touchstoneVersionId/scenarios/" component={ScenarioPage}/>
-        <Route exact path="/touchstones/:touchstoneId/:touchstoneVersionId/coverage/" component={CoveragePage}/>
+        { props.permissions.indexOf("*/coverage.write") > -1 &&
+            <Route exact path="/touchstones/:touchstoneId/:touchstoneVersionId/coverage/" component={CoveragePage}/>
+        }
         <Route exact path="/touchstones/:touchstoneId/:touchstoneVersionId/coverage/coverage-variables/" component={CoverageVariablesPage}/>
         <Route exact path="/users/" component={UsersListPage}/>
         <Route exact path="/users/:username/" component={UserDetailsPage}/>

--- a/app/src/main/admin/components/AdminRouter.tsx
+++ b/app/src/main/admin/components/AdminRouter.tsx
@@ -4,6 +4,8 @@ import {ConnectedRouter} from 'react-router-redux';
 import {History} from "history";
 import * as logo from "../../shared/components/PageWithHeader/logo.png"
 import {PageHeader} from "../../shared/components/PageWithHeader/PageHeader";
+import {AdminAppState} from "../reducers/adminAppReducers";
+import {connect} from "react-redux";
 // Pages
 import {AdminNoRouteFoundPage} from "./AdminNoRouteFoundPage";
 import {ModellingGroupsListPage} from "./ModellingGroups/List/ModellingGroupsListPage";
@@ -22,11 +24,6 @@ import {CoveragePage} from "./Touchstones/Coverage/CoveragePage";
 import {LoginPage} from "../../shared/components/LoginPage";
 import {ModelMetaPage} from "./ModellingGroups/Models/ModelMetaPage";
 import {CoverageVariablesPage} from "./Touchstones/Coverage/CoverageVariablesPage";
-import {AdminAppState} from "../reducers/adminAppReducers";
-import {UserDetailsProps} from "./Users/SingleUser/UserDetailsContent";
-import {connect} from "react-redux";
-import {mapStateToAppProps} from "../../shared/components/App";
-import {AdminAppComponent} from "./AdminApp";
 
 interface AdminRouterProps {
     loggedIn: boolean;

--- a/app/src/main/admin/components/AdminRouter.tsx
+++ b/app/src/main/admin/components/AdminRouter.tsx
@@ -24,14 +24,17 @@ import {ModelMetaPage} from "./ModellingGroups/Models/ModelMetaPage";
 import {CoverageVariablesPage} from "./Touchstones/Coverage/CoverageVariablesPage";
 import {AdminAppState} from "../reducers/adminAppReducers";
 import {UserDetailsProps} from "./Users/SingleUser/UserDetailsContent";
+import {connect} from "react-redux";
+import {mapStateToAppProps} from "../../shared/components/App";
+import {AdminAppComponent} from "./AdminApp";
 
 interface AdminRouterProps {
     loggedIn: boolean;
-    permissions: string[];
     history: History;
+    canUploadCoverage: boolean;
 }
 
-export const AdminRouter: React.FunctionComponent<AdminRouterProps> = (props: AdminRouterProps) => {
+export const AdminRouterComponent: React.FunctionComponent<AdminRouterProps> = (props: AdminRouterProps) => {
 
     const loggedIn = <Switch>
         <Route exact path="/" component={MainMenuPage}/>
@@ -47,7 +50,7 @@ export const AdminRouter: React.FunctionComponent<AdminRouterProps> = (props: Ad
         <Route exact path="/touchstones/:touchstoneId/:touchstoneVersionId/demographics/"
                component={DownloadDemographicsAdminPage}/>
         <Route exact path="/touchstones/:touchstoneId/:touchstoneVersionId/scenarios/" component={ScenarioPage}/>
-        { props.permissions.indexOf("*/coverage.write") > -1 &&
+        { props.canUploadCoverage &&
             <Route exact path="/touchstones/:touchstoneId/:touchstoneVersionId/coverage/" component={CoveragePage}/>
         }
         <Route exact path="/touchstones/:touchstoneId/:touchstoneVersionId/coverage/coverage-variables/" component={CoverageVariablesPage}/>
@@ -69,3 +72,13 @@ export const AdminRouter: React.FunctionComponent<AdminRouterProps> = (props: Ad
         </div>
     </ConnectedRouter>;
 };
+
+export const mapStateToProps = (state: AdminAppState, props: Partial<AdminRouterProps>): AdminRouterProps => {
+    return {
+        history: props.history,
+        loggedIn: state.auth.loggedIn,
+        canUploadCoverage: state.auth.canUploadCoverage
+    }
+};
+
+export const AdminRouter = connect(mapStateToProps)(AdminRouterComponent);

--- a/app/src/main/shared/components/App.ts
+++ b/app/src/main/shared/components/App.ts
@@ -3,12 +3,14 @@ import {History} from "history";
 
 export interface AppProps {
     loggedIn: boolean;
+    permissions: string[];
     history?: History;
 }
 
 export const mapStateToAppProps = (state: CommonState, props: Partial<AppProps>): AppProps => {
     return {
         loggedIn: state.auth.loggedIn,
+        permissions: state.auth.permissions,
         history: props.history
     }
 };

--- a/app/src/main/shared/components/App.ts
+++ b/app/src/main/shared/components/App.ts
@@ -3,14 +3,12 @@ import {History} from "history";
 
 export interface AppProps {
     loggedIn: boolean;
-    permissions: string[];
     history?: History;
 }
 
 export const mapStateToAppProps = (state: CommonState, props: Partial<AppProps>): AppProps => {
     return {
         loggedIn: state.auth.loggedIn,
-        permissions: state.auth.permissions,
         history: props.history
     }
 };

--- a/app/src/main/shared/reducers/authReducer.ts
+++ b/app/src/main/shared/reducers/authReducer.ts
@@ -10,6 +10,7 @@ export interface AuthState {
     isAccountActive: boolean;
     isModeller: boolean;
     errorMessage?: string;
+    canUploadCoverage: boolean;
 }
 
 export const initialAuthState: AuthState = {
@@ -18,7 +19,8 @@ export const initialAuthState: AuthState = {
     bearerToken: null,
     permissions: [],
     isAccountActive: false,
-    isModeller: false
+    isModeller: false,
+    canUploadCoverage: false
 };
 
 export interface AuthStateOptions {
@@ -29,15 +31,18 @@ export interface AuthStateOptions {
     modellingGroups: string[]
 }
 
+const permissionsInclude = (permissions: string[], perm: string) => permissions.some((x: string) => x == perm);
+
 export function loadAuthState(options: AuthStateOptions): AuthState {
     return {
         loggedIn: options.loggedIn,
         bearerToken: options.bearerToken,
-        isAccountActive: options.permissions.some((x: string) => x == "*/can-login"),
+        isAccountActive: permissionsInclude(options.permissions,"*/can-login"),
         isModeller: options.modellingGroups.length > 0,
         username: options.username,
         permissions: options.permissions,
-        modellingGroups: options.modellingGroups
+        modellingGroups: options.modellingGroups,
+        canUploadCoverage: permissionsInclude(options.permissions, "*/coverage.write")
     }
 }
 

--- a/app/src/test/admin/components/AdminAppTests.tsx
+++ b/app/src/test/admin/components/AdminAppTests.tsx
@@ -5,11 +5,11 @@ import {AdminApp, AdminAppComponent} from "../../../main/admin/components/AdminA
 import {AdminRouter} from "../../../main/admin/components/AdminRouter";
 
 describe("AdminApp", () => {
-    it("passes through loggedIn to router", () => {
-        const rendered = shallow(<AdminAppComponent loggedIn={ true } />);
+    it("passes through history to router", () => {
+        const rendered = shallow(<AdminAppComponent loggedIn={ true } history={ "TEST HISTORY" as any } />);
         expect(rendered.find(AdminRouter).props()).toEqual({
-            loggedIn: true,
-            history: undefined
+            loggedIn: undefined,
+            history: "TEST HISTORY"
         });
     });
 });

--- a/app/src/test/admin/components/AdminAppTests.tsx
+++ b/app/src/test/admin/components/AdminAppTests.tsx
@@ -3,10 +3,12 @@ import * as React from "react";
 import {shallow} from "enzyme";
 import {AdminApp, AdminAppComponent} from "../../../main/admin/components/AdminApp";
 import {AdminRouter} from "../../../main/admin/components/AdminRouter";
+import {createMockAdminStore} from "../../mocks/mockStore";
 
 describe("AdminApp", () => {
     it("passes through history to router", () => {
-        const rendered = shallow(<AdminAppComponent loggedIn={ true } history={ "TEST HISTORY" as any } />);
+        const store = createMockAdminStore();
+        const rendered = shallow(<AdminApp history={ "TEST HISTORY" as any } />, {context: {store}}).dive();
         expect(rendered.find(AdminRouter).props()).toEqual({
             loggedIn: undefined,
             history: "TEST HISTORY"

--- a/app/src/test/admin/components/AdminRouterTests.tsx
+++ b/app/src/test/admin/components/AdminRouterTests.tsx
@@ -14,7 +14,6 @@ import {createMockAdminStore} from "../../mocks/mockStore";
 import {RecursivePartial} from "../../mocks/mockStates";
 import {AdminAppState} from "../../../main/admin/reducers/adminAppReducers";
 import {CoveragePage} from "../../../main/admin/components/Touchstones/Coverage/CoveragePage";
-import {Route} from "react-router";
 
 describe("AdminRouter", () => {
 
@@ -24,14 +23,14 @@ describe("AdminRouter", () => {
         sandbox.restore();
     });
 
-    function renderComponent(state: RecursivePartial<AdminAppState>, route="/") {
+    function renderComponent(state: RecursivePartial<AdminAppState>, route: string) {
         const history = createMemoryHistory({initialEntries: [route]});
         const store = createMockAdminStore(state);
         return mount(<Provider store={store}><AdminRouter history={history}/></Provider>);
     }
 
     it("does normal routing when logged in", () => {
-        const rendered = renderComponent({auth: {loggedIn: true}});
+        const rendered = renderComponent({auth: {loggedIn: true}}, "/asd");
         expect(rendered.find(AdminNoRouteFoundPage)).toHaveLength(1);
     });
 

--- a/app/src/test/mocks/mockStates.ts
+++ b/app/src/test/mocks/mockStates.ts
@@ -34,7 +34,8 @@ export const mockAuthStateObject: AuthState = {
     permissions: [],
     modellingGroups: [],
     isAccountActive: true,
-    isModeller: false
+    isModeller: false,
+    canUploadCoverage: false
 };
 
 export const mockAuthState = (props?: RecursivePartial<AuthState>) => {

--- a/app/src/test/shared/reducers/AuthReducersTests.ts
+++ b/app/src/test/shared/reducers/AuthReducersTests.ts
@@ -11,7 +11,8 @@ const testAuthData: AuthState = {
     bearerToken: 'testtoken',
     permissions: [],
     isAccountActive: true,
-    isModeller: false
+    isModeller: false,
+    canUploadCoverage: false
 };
 
 describe('Auth reducer tests', () => {
@@ -63,39 +64,32 @@ describe('Auth reducer tests', () => {
 });
 
 describe ('loadAuthState tests', () => {
-    it('loads basic param values', () => {
-        const result = loadAuthState({
-            username: "testUser",
-            loggedIn: true,
-            bearerToken: "testToken",
-            permissions: ["perm1", "perm2"],
-            modellingGroups: ["group1", "group2"]
-            });
+    const basicOptions = {
+        username: "testUser",
+        loggedIn: true,
+        bearerToken: "testToken",
+        permissions: ["perm1", "perm2"],
+        modellingGroups: ["group1", "group2"]
+    };
 
+    it('loads basic param values', () => {
+        const result = loadAuthState(basicOptions);
         expect(result.username).toEqual("testUser");
         expect(result.loggedIn).toEqual(true);
         expect(result.bearerToken).toEqual("testToken");
         expect(result.permissions).toEqual(["perm1", "perm2"]);
         expect(result.modellingGroups).toEqual(["group1", "group2"]);
+        expect(result.canUploadCoverage).toBe(false);
     });
 
     it('sets isAccountActive correctly', () => {
-        const inactive = loadAuthState({
-            username: "testUser",
-            loggedIn: true,
-            bearerToken: "testToken",
-            permissions: ["perm1", "perm2"],
-            modellingGroups: ["group1", "group2"]
-        });
+        const inactive = loadAuthState(basicOptions);
 
         expect(inactive.isAccountActive).toEqual(false);
 
         const active = loadAuthState({
-            username: "testUser",
-            loggedIn: true,
-            bearerToken: "testToken",
-            permissions: ["*/can-login", "perm1", "perm2"],
-            modellingGroups: ["group1", "group2"]
+            ...basicOptions,
+            permissions: ["*/can-login", "perm1", "perm2"]
         });
 
         expect(active.isAccountActive).toEqual(true)
@@ -104,24 +98,21 @@ describe ('loadAuthState tests', () => {
 
     it('sets isModeller correctly', () => {
 
-        const modeller = loadAuthState({
-            username: "testUser",
-            loggedIn: true,
-            bearerToken: "testToken",
-            permissions: ["perm1", "perm2"],
-            modellingGroups: ["group1", "group2"]
-        });
+        const modeller = loadAuthState(basicOptions);
         expect(modeller.isModeller).toEqual(true);
 
         const nonModeller = loadAuthState({
-            username: "testUser",
-            loggedIn: true,
-            bearerToken: "testToken",
-            permissions: ["perm1", "perm2"],
+            ...basicOptions,
             modellingGroups: [] as string[]
         });
         expect(nonModeller.isModeller).toEqual(false);
     });
 
-
+    it('sets canUploadCoverage if coverage write permission present', () => {
+        const result = loadAuthState({
+            ...basicOptions,
+            permissions: ["*/coverage.write", "perm1", "perm2"]
+        });
+        expect(result.canUploadCoverage).toBe(true);
+    });
 });


### PR DESCRIPTION
Interestingly, what this ticket has revealed is that, in fact, we do not currently lock down any other routes in the portals! We just strategically hide links to the pages, and the user who stumbles on a route they shouldn't find will just have a bad time, because the API which is serving the data will return 401s when the portal requests it. 

I think we got away with this before, when the modellers accessing the contrib portal, and admin users accessing the admin portal would probably all have much the same sets of permissions, but now that we'll be opening the Admin portal to GAVI users with restricted privileges to upload coverage only we should probably be more stringent. 

Making this ticket a proof of concept for putting this in for the coverage route, and have made another ticket for covering all the routes (https://mrc-ide.myjetbrains.com/youtrack/issue/mrc-2034). The router will not add routes the user is not permitted to access, and the user will see the 'Page not found' screen if they attempt to browse to the route. 

I've rearranged the top-level components a little, so that the router can now access properties in the state directly rather than receiving them as props - this means less boiler plate when we add switching route addition on the user's permissions for the other pages. I've also added canUploadCoverage to the auth state - we will use this from the touchstone page when we add the coverage link. Again, this can be a pattern we repeat when we conditionally add the other routes - currently many components calculate their own canDoSomething properties when deciding whether to add links, but we can move those into the state to be accessible from the router too. 

This can be manually tested locally by removing the line `$here/cli.sh addRole test.user coverage-provider` from `add-test-accounts-for-integration-tests.sh` and rerunning dev dependencies. Browse to a touchstone version page, and append `/coverage` to attempt to access the coverage page. 