### PR TITLE
vimc-4461 Put canDoThing properties on auth state rather than components

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -96,7 +96,7 @@ management.
 
 # User permissions
 
-Users can access some areas of the portals dependent on the permissions they possess. Raw user permissions from the [Montagu
+Users can access some areas of the admin portal dependent on the permissions they possess. Raw user permissions from the [Montagu
 database](https://github.com/vimc/montagu-db) are converted into properties on the `AuthState` interface, indicating what
 the user is allowed to do in the portals. These properties are used by the components to determine whether links and
 controls should be shown to the user. In addition, the [Montagu API](https://github.com/vimc/montagu-api) will prevent 

--- a/app/README.md
+++ b/app/README.md
@@ -93,3 +93,27 @@ Short name: `admin`
 This portal allows administrative staff to set up touchstones with all the
 necessary input data, responsibilities and recipes. It's also where we do user
 management.
+
+# User permissions
+
+Users can access some areas of the portals dependent on the permissions they possess. Raw user permissions from the [Montagu
+database](https://github.com/vimc/montagu-db) are converted into properties on the `AuthState` interface, indicating what
+the user is allowed to do in the portals. These properties are used by the components to determine whether links and
+controls should be shown to the user. In addition, the [Montagu API](https://github.com/vimc/montagu-api) will prevent 
+the user taking any actions for which they do not have permissions.
+
+The `AuthState` properties, and their corresponding permissions are:
+
+| Property | Permission | Used in
+| --- | --- | --- |
+| `canDownloadCoverage` | `*/coverage.read` | Touchstone scenarios page
+| `canUploadCoverage` | `*/coverage.write` | Touchstone coverage upload page
+| `canViewGroups` | `*/modelling-groups.read` | Main menu 
+| `canViewTouchstones` | `*/touchstones.read` | Main menu
+| `canViewUsers` | `*/users.read` | Main Menu
+| `canReadRoles` | `*/roles.read` | User details page
+| `canWriteRoles` | `*/roles.write` | User details page
+| `canCreateUsers` | `*/users.create` | Users page (CreateUsersSection component)
+| `canCreateModellingGroups` | `*/modelling-groups.write` | Modelling Groups page (CreateModellingGroupSection component)
+| `canManageGroupMembers` | `*/modelling-groups.manage-members` | Modelling Group details page (several components)
+

--- a/app/src/main/admin/actions/pages/UserDetailsPageActionCreators.ts
+++ b/app/src/main/admin/actions/pages/UserDetailsPageActionCreators.ts
@@ -25,7 +25,7 @@ export class UserDetailsPageActionCreators extends AdminPageActionCreators<UserD
         return async (dispatch: Dispatch<AdminAppState>, getState: () => AdminAppState) => {
 
             dispatch(usersActionCreators.setCurrentUser(params.username));
-            if (getState().auth.permissions.indexOf("*/roles.read") > -1) {
+            if (getState().auth.canReadRoles) {
                 dispatch(usersActionCreators.getGlobalRoles())
             }
         }

--- a/app/src/main/admin/components/MainMenu/MainMenu.tsx
+++ b/app/src/main/admin/components/MainMenu/MainMenu.tsx
@@ -40,9 +40,9 @@ class MainMenuListComponent extends React.Component<Props> {
 }
 
 const mapStateToProps = (state: AdminAppState): Props => ({
-    canViewGroups: state.auth.permissions.indexOf("*/modelling-groups.read") > -1,
-    canViewTouchstones: state.auth.permissions.indexOf("*/touchstones.read") > -1,
-    canViewUsers: state.auth.permissions.indexOf("*/users.read") > -1
+    canViewGroups: state.auth.canViewGroups,
+    canViewTouchstones: state.auth.canViewTouchstones,
+    canViewUsers: state.auth.canViewUsers
 });
 
 export const MainMenuList = compose(

--- a/app/src/main/admin/components/ModellingGroups/Create/CreateModellingGroupSection.tsx
+++ b/app/src/main/admin/components/ModellingGroups/Create/CreateModellingGroupSection.tsx
@@ -28,7 +28,7 @@ export const CreateModellingGroupSectionComponent = (props: CreateModellingGroup
 
 export const mapStateToProps = (state: AdminAppState): Partial<CreateModellingGroupSectionProps> => {
     return {
-        canCreateModellingGroups: state.auth.permissions.indexOf("*/users.create") > -1,
+        canCreateModellingGroups: state.auth.canCreateModellingGroups,
         show: state.groups.showCreateGroupForm
     }
 };

--- a/app/src/main/admin/components/ModellingGroups/SingleGroup/Details/ModellingGroupDetailsContent.tsx
+++ b/app/src/main/admin/components/ModellingGroups/SingleGroup/Details/ModellingGroupDetailsContent.tsx
@@ -36,7 +36,7 @@ const mapStateToProps = (state: AdminAppState) :Partial<ModellingGroupDetailsCon
     return {
         group: state.groups.currentGroupDetails,
         members: state.groups.currentGroupMembers,
-        canManageGroupMembers: state.auth.permissions.indexOf("*/modelling-groups.manage-members") > -1
+        canManageGroupMembers: state.auth.canManageGroupMembers
     }
 };
 

--- a/app/src/main/admin/components/ModellingGroups/SingleGroup/Members/ModellingGroupMembersContent.tsx
+++ b/app/src/main/admin/components/ModellingGroups/SingleGroup/Members/ModellingGroupMembersContent.tsx
@@ -42,7 +42,7 @@ export const ModellingGroupMembersContentComponent: React.FunctionComponent<Mode
 
 export const mapStateToProps = (state: AdminAppState) :Partial<ModellingGroupMembersContentProps> => {
     return {
-        canManageGroupMembers: state.auth.permissions.indexOf("*/modelling-groups.manage-members") > -1,
+        canManageGroupMembers: state.auth.canManageGroupMembers,
         groupId: state.groups.currentGroupDetails ? state.groups.currentGroupDetails.id : null,
         users: state.users.users,
         members: state.groups.currentGroupMembers,

--- a/app/src/main/admin/components/ModellingGroups/SingleGroup/Members/ModellingGroupMembersList.tsx
+++ b/app/src/main/admin/components/ModellingGroups/SingleGroup/Members/ModellingGroupMembersList.tsx
@@ -38,7 +38,7 @@ const mapSortUsers = (users: User[]) => {
 
 const mapStateToProps = (state: AdminAppState, props: Partial<ModellingGroupMembersListProps>) :Partial<ModellingGroupMembersListProps> => {
     return {
-        isAdmin: state.auth.permissions.indexOf("*/modelling-groups.manage-members") > -1,
+        isAdmin: state.auth.canManageGroupMembers,
         users: mapSortUsers(props.users),
         groupId: props.groupId
     }

--- a/app/src/main/admin/components/Touchstones/Scenarios/ScenariosList.tsx
+++ b/app/src/main/admin/components/Touchstones/Scenarios/ScenariosList.tsx
@@ -4,7 +4,6 @@ import * as React from "react";
 import {connect} from "react-redux";
 import {ScenarioGroup} from "./ScenarioGroup";
 import {discardDispatch} from "../../../../shared/Helpers";
-import {UncontrolledTooltip} from "reactstrap";
 
 export interface ScenariosListProps {
     scenarios: Scenario[];
@@ -33,7 +32,7 @@ function mapStateToProps(state: AdminAppState): ScenariosListProps {
     return {
         scenarios: state.scenario.scenarios.filter(s => s.touchstones.some(t => t == touchstoneVersionId)),
         diseases: state.diseases.diseases,
-        canDownloadCoverage: state.auth.permissions.indexOf("*/coverage.read") > -1,
+        canDownloadCoverage: state.auth.canDownloadCoverage,
         touchstoneVersionId: touchstoneVersionId
     }
 }

--- a/app/src/main/admin/components/Users/Create/CreateUserSection.tsx
+++ b/app/src/main/admin/components/Users/Create/CreateUserSection.tsx
@@ -31,7 +31,7 @@ export class CreateUserSectionComponent extends React.Component<Partial<CreateUs
 export const mapStateToProps = (state: AdminAppState): Partial<CreateUserSectionProps> => {
     return {
         show: state.users.showCreateUser,
-        canCreateUsers: state.auth.permissions.indexOf("*/users.create") > -1
+        canCreateUsers: state.auth.canCreateUsers
     }
 };
 

--- a/app/src/main/admin/components/Users/SingleUser/UserDetailsContent.tsx
+++ b/app/src/main/admin/components/Users/SingleUser/UserDetailsContent.tsx
@@ -67,8 +67,8 @@ export const UserDetailsContentComponent: React.FunctionComponent<UserDetailsPro
 
 export const mapStateToProps = (state: AdminAppState): UserDetailsProps => {
     return {
-        canReadRoles: state.auth.permissions.indexOf("*/roles.read") > -1,
-        canWriteRoles: state.auth.permissions.indexOf("*/roles.write") > -1,
+        canReadRoles: state.auth.canReadRoles,
+        canWriteRoles: state.auth.canWriteRoles,
         user: state.users.currentUser,
     }
 };

--- a/app/src/main/shared/reducers/authReducer.ts
+++ b/app/src/main/shared/reducers/authReducer.ts
@@ -66,7 +66,7 @@ export function loadAuthState(options: AuthStateOptions): AuthState {
         canReadRoles: permissionsInclude(options.permissions,"*/roles.read"),
         canWriteRoles: permissionsInclude(options.permissions,"*/roles.write"),
         canCreateUsers: permissionsInclude(options.permissions,"*/users.create"),
-        canCreateModellingGroups: permissionsInclude(options.permissions,"*/users.create"),
+        canCreateModellingGroups: permissionsInclude(options.permissions,"*/modelling-groups.write"),
         canManageGroupMembers: permissionsInclude(options.permissions,"*/modelling-groups.manage-members")
     }
 }

--- a/app/src/main/shared/reducers/authReducer.ts
+++ b/app/src/main/shared/reducers/authReducer.ts
@@ -5,22 +5,38 @@ export interface AuthState {
     loggedIn: boolean;
     username: string;
     bearerToken: string;
-    permissions: string[];
     modellingGroups?: string[];
     isAccountActive: boolean;
     isModeller: boolean;
     errorMessage?: string;
+    canDownloadCoverage: boolean;
     canUploadCoverage: boolean;
+    canViewGroups: boolean;
+    canViewTouchstones: boolean;
+    canViewUsers: boolean;
+    canReadRoles: boolean;
+    canWriteRoles: boolean;
+    canCreateUsers: boolean;
+    canCreateModellingGroups: boolean;
+    canManageGroupMembers: boolean;
 }
 
 export const initialAuthState: AuthState = {
     loggedIn: false,
     username: null,
     bearerToken: null,
-    permissions: [],
     isAccountActive: false,
     isModeller: false,
-    canUploadCoverage: false
+    canDownloadCoverage: false,
+    canUploadCoverage: false,
+    canViewGroups: false,
+    canViewTouchstones: false,
+    canViewUsers: false,
+    canReadRoles: false,
+    canWriteRoles: false,
+    canCreateUsers: false,
+    canCreateModellingGroups: false,
+    canManageGroupMembers: false
 };
 
 export interface AuthStateOptions {
@@ -40,9 +56,18 @@ export function loadAuthState(options: AuthStateOptions): AuthState {
         isAccountActive: permissionsInclude(options.permissions,"*/can-login"),
         isModeller: options.modellingGroups.length > 0,
         username: options.username,
-        permissions: options.permissions,
         modellingGroups: options.modellingGroups,
-        canUploadCoverage: permissionsInclude(options.permissions, "*/coverage.write")
+
+        canDownloadCoverage: permissionsInclude(options.permissions,"*/coverage.read"),
+        canUploadCoverage: permissionsInclude(options.permissions, "*/coverage.write"),
+        canViewGroups: permissionsInclude(options.permissions,"*/modelling-groups.read"),
+        canViewTouchstones: permissionsInclude(options.permissions,"*/touchstones.read"),
+        canViewUsers: permissionsInclude(options.permissions, "*/users.read"),
+        canReadRoles: permissionsInclude(options.permissions,"*/roles.read"),
+        canWriteRoles: permissionsInclude(options.permissions,"*/roles.write"),
+        canCreateUsers: permissionsInclude(options.permissions,"*/users.create"),
+        canCreateModellingGroups: permissionsInclude(options.permissions,"*/users.create"),
+        canManageGroupMembers: permissionsInclude(options.permissions,"*/modelling-groups.manage-members")
     }
 }
 

--- a/app/src/test/admin/actions/pages/UserDetailsPageActionCreatorTests.ts
+++ b/app/src/test/admin/actions/pages/UserDetailsPageActionCreatorTests.ts
@@ -54,7 +54,7 @@ describe("User Details Page actions tests", () => {
 
     it("sets current user and gets global roles on load", async () => {
 
-        store = createMockStore(mockAdminState({auth: {permissions: ["*/roles.read"]}}));
+        store = createMockStore(mockAdminState({auth: {canReadRoles: true}}));
         await store.dispatch(userDetailsPageActionCreators.loadData({username: "test.user"}));
 
         const actions = store.getActions();

--- a/app/src/test/admin/components/MainMenuTests.tsx
+++ b/app/src/test/admin/components/MainMenuTests.tsx
@@ -5,15 +5,14 @@ import {MainMenuList} from "../../../main/admin/components/MainMenu/MainMenu";
 import {createMockStore} from "../../mocks/mockStore";
 import {mockAdminState, mockAuthState} from "../../mocks/mockStates";
 import {ButtonLink} from "../../../main/shared/components/ButtonLink";
+import {AuthState} from "../../../main/shared/reducers/authReducer";
 
 
 describe("Admin main menu tests", () => {
 
-    function createStoreWithPermissions(permissions: string[]) {
+    function createStoreWithAuth(auth: Partial<AuthState>) {
         return createMockStore(mockAdminState({
-            auth: mockAuthState({
-                permissions: permissions
-            })
+            auth: mockAuthState(auth)
         }));
     }
 
@@ -28,7 +27,7 @@ describe("Admin main menu tests", () => {
 
     it("show touchstone button if user has permission", () => {
 
-        const store = createStoreWithPermissions(["*/touchstones.read"]);
+        const store = createStoreWithAuth({canViewTouchstones: true});
 
         const rendered = shallow(<MainMenuList/>, {context: {store}})
             .dive();
@@ -40,7 +39,7 @@ describe("Admin main menu tests", () => {
 
     it("show users button if user has permission", () => {
 
-        const store = createStoreWithPermissions(["*/users.read"]);
+        const store = createStoreWithAuth({canViewUsers: true});
 
         const rendered = shallow(<MainMenuList/>, {context: {store}})
             .dive(); const buttons = rendered.find(ButtonLink);
@@ -51,7 +50,7 @@ describe("Admin main menu tests", () => {
 
     it("show groups button if user has permission", () => {
 
-        const store = createStoreWithPermissions(["*/modelling-groups.read"]);
+        const store = createStoreWithAuth({canViewGroups: true});
 
         const rendered = shallow(<MainMenuList/>, {context: {store}})
             .dive();

--- a/app/src/test/admin/components/ModellingGroups/SingleGroup/Details/ModellingGroupDetailsContentTests.tsx
+++ b/app/src/test/admin/components/ModellingGroups/SingleGroup/Details/ModellingGroupDetailsContentTests.tsx
@@ -25,10 +25,10 @@ describe("Modelling Group Details Content Component tests", () => {
         const sandbox = new Sandbox();
         afterEach(() => sandbox.restore());
 
-        it("props on connect level, can manage", () => {
+        it("props on connect level", () => {
             const testState = {
                 groups: { currentGroupDetails: testGroupDetails, currentGroupMembers: [testUser, testUser2]},
-                auth: { permissions: ["*/modelling-groups.manage-members"] }
+                auth: { canManageGroupMembers: true }
             };
             const store = createMockStore(testState);
             const rendered = shallow(<ModellingGroupDetailsContent/>, {context: {store}});
@@ -36,18 +36,6 @@ describe("Modelling Group Details Content Component tests", () => {
             expect(rendered.props().members).toEqual([testUser, testUser2]);
             expect(rendered.props().canManageGroupMembers).toBe(true);
         });
-
-        it("props on connect level, can not manage", () => {
-            const testState = {
-                groups: { currentGroupDetails: testGroupDetails},
-                users: { users: [testUser, testUser2]},
-                auth: { permissions: ["test"] }
-            };
-            const store = createMockStore(testState);
-            const rendered = shallow(<ModellingGroupDetailsContent/>, {context: {store}});
-            expect(rendered.props().canManageGroupMembers).toBe(false);
-        });
-
     });
 
     describe("Component", () => {

--- a/app/src/test/admin/components/ModellingGroups/SingleGroup/Members/ModellingGroupMembersContentTests.tsx
+++ b/app/src/test/admin/components/ModellingGroups/SingleGroup/Members/ModellingGroupMembersContentTests.tsx
@@ -28,7 +28,7 @@ describe("Modelling Group Members Content component tests", () => {
         it("connect level, can edit, there are members", () => {
             const testGroupDetails = mockModellingGroupDetails({members: [testUser.username]});
             const testState = {
-                auth: { permissions: ["*/modelling-groups.manage-members"]},
+                auth: { canManageGroupMembers: true},
                 groups: { currentGroupDetails: testGroupDetails, currentGroupMembers: [testUser] },
                 users: { users: [testUser, testUser2]},
             };
@@ -45,7 +45,7 @@ describe("Modelling Group Members Content component tests", () => {
         it("connect level, can not edit, there are no members", () => {
             const testGroupDetails = mockModellingGroupDetails({members: []});
             const testState = {
-                auth: { permissions: ["test"]},
+                auth: { canManageGroupMembers: false},
                 groups: { currentGroupDetails: testGroupDetails, currentGroupMembers: [] as any},
                 users: { users: [testUser, testUser2]},
 

--- a/app/src/test/admin/components/ModellingGroups/SingleGroup/Members/ModellingGroupMembersListTests.tsx
+++ b/app/src/test/admin/components/ModellingGroups/SingleGroup/Members/ModellingGroupMembersListTests.tsx
@@ -11,7 +11,6 @@ import { mockUser } from "../../../../../mocks/mockModels";
 import { Sandbox } from "../../../../../Sandbox";
 import { ModellingGroupMembersDeletableUser } from "../../../../../../main/admin/components/ModellingGroups/SingleGroup/Members/ModellingGroupMembersDeletableUser";
 import {createMockStore} from "../../../../../mocks/mockStore";
-// import { reduxHelper } from "../../../../../reduxHelper";
 
 describe("Modelling Group Members List component tests", () => {
 
@@ -26,7 +25,7 @@ describe("Modelling Group Members List component tests", () => {
 
         it("connect level, there are users and can manage", () => {
             const testState = {
-                auth: { permissions: ["*/modelling-groups.manage-members"]},
+                auth: { canManageGroupMembers: true},
             };
             const store = createMockStore(testState);
 
@@ -41,7 +40,7 @@ describe("Modelling Group Members List component tests", () => {
 
         it("connect level, there are no users and can not manage", () => {
             const testState = {
-                auth: { permissions: ["*/test"]},
+                auth: { canManageGroupMembers: false },
             };
             const store = createMockStore(testState);
 

--- a/app/src/test/admin/components/Touchstones/Scenarios/ScenariosListTests.tsx
+++ b/app/src/test/admin/components/Touchstones/Scenarios/ScenariosListTests.tsx
@@ -33,7 +33,7 @@ describe("ScenariosList", () => {
     });
 
     it(
-        "canDownloadCoverage is true when user has global coverage reading permission",
+        "canDownloadCoverage is true when user has permission in auth state",
         () => {
             const touchstoneVersionId = "t1";
             const scenarios = [
@@ -45,7 +45,7 @@ describe("ScenariosList", () => {
             const store = createMockAdminStore({
                 scenario: {scenarios},
                 diseases: {diseases},
-                auth: {permissions: ["*/coverage.read"]},
+                auth: {canDownloadCoverage: true},
                 touchstones: {currentTouchstoneVersion: mockTouchstoneVersion({id: touchstoneVersionId})}
             });
             const rendered = shallow(<ScenariosList/>, {context: {store}});
@@ -73,7 +73,8 @@ describe("ScenariosList", () => {
             const store = createMockAdminStore({
                 scenario: {scenarios: d1scenarios.concat(d2scenarios)},
                 diseases: {diseases: [disease1, disease2]},
-                touchstones: {currentTouchstoneVersion: mockTouchstoneVersion({id: touchstoneVersionId})}
+                touchstones: {currentTouchstoneVersion: mockTouchstoneVersion({id: touchstoneVersionId})},
+                auth: {canDownloadCoverage: false}
             });
             const rendered = shallow(<ScenariosList/>, {context: {store}}).dive();
             const groups = rendered.find(ScenarioGroup);

--- a/app/src/test/admin/components/Users/Create/CreateUserSectionTests.tsx
+++ b/app/src/test/admin/components/Users/Create/CreateUserSectionTests.tsx
@@ -8,18 +8,16 @@ import {usersActionCreators} from "../../../../../main/admin/actions/usersAction
 import {mockAdminState, mockAdminUsersState, mockAuthState} from "../../../../mocks/mockStates";
 import {createMockStore} from "../../../../mocks/mockStore";
 
-describe("CreateUserSectionComponenent", () => {
+describe("CreateUserSectionComponent", () => {
     const sandbox = new Sandbox();
     afterEach(() => sandbox.restore());
 
     it(
-        "renders form when 'showCreateUser' is true and user has 'users-create' permission",
+        "renders form when 'showCreateUser' is true and user can create users",
         () => {
             const store = createMockStore(mockAdminState({
                 users: mockAdminUsersState({showCreateUser: true}),
-                auth: mockAuthState({
-                    permissions: ["*/users.create"]
-                })
+                auth: mockAuthState({canCreateUsers: true})
             }));
             const rendered = shallow(<CreateUserSection/>, {context: {store}}).dive().dive();
             expect(rendered.find(CreateUserForm)).toHaveLength(1);
@@ -28,13 +26,11 @@ describe("CreateUserSectionComponenent", () => {
     );
 
     it(
-        "renders button when 'showCreateUser' is false and user has 'users-create' permission",
+        "renders button when 'showCreateUser' is false and user can create users",
         () => {
             const store = createMockStore(mockAdminState({
                 users: mockAdminUsersState({showCreateUser: false}),
-                auth: mockAuthState({
-                    permissions: ["*/users.create"]
-                })
+                auth: mockAuthState({canCreateUsers: true})
             }));
             const rendered = shallow(<CreateUserSection/>, {context: {store}}).dive().dive();
             expect(rendered.find(CreateUserForm)).toHaveLength(0);
@@ -43,9 +39,12 @@ describe("CreateUserSectionComponenent", () => {
     );
 
     it(
-        "renders nothing when user does not have 'users-create' permission",
+        "renders nothing when user cannot create users",
         () => {
-            const store = createMockStore(mockAdminState({users: mockAdminUsersState({showCreateUser: false})}));
+            const store = createMockStore(mockAdminState({
+                users: mockAdminUsersState({showCreateUser: false}),
+                auth: mockAuthState({canCreateUsers: false})
+            }));
             const rendered = shallow(<CreateUserSection/>, {context: {store}}).dive().dive();
             expect(rendered.find("button")).toHaveLength(0);
             expect(rendered.find("div")).toHaveLength(0);
@@ -55,9 +54,7 @@ describe("CreateUserSectionComponenent", () => {
     it("button triggers setShowCreateUser", () => {
         const store = createMockStore(mockAdminState({
             users: mockAdminUsersState({showCreateUser: false}),
-            auth: mockAuthState({
-                permissions: ["*/users.create"]
-            })
+            auth: mockAuthState({canCreateUsers: true})
         }));
         const spy = sandbox.setStubReduxAction(usersActionCreators, "setShowCreateUser");
         const rendered = shallow(<CreateUserSection/>, {context: {store}}).dive().dive();

--- a/app/src/test/admin/components/Users/SingleUser/UserDetailsComponentTests.tsx
+++ b/app/src/test/admin/components/Users/SingleUser/UserDetailsComponentTests.tsx
@@ -30,38 +30,28 @@ describe("UserDetailsContent", () => {
     });
 
     it(
-        "maps canReadRoles property to true if user has '*roles.read' permission",
+        "gets canReadRoles property from auth state",
         () => {
-            const adminStateMock = mockAdminState({auth: mockAuthState({permissions: ["*/roles.read"]})});
-            const props = mapStateToProps(adminStateMock);
+            let adminStateMock = mockAdminState({auth: mockAuthState({canReadRoles: false})});
+            let props = mapStateToProps(adminStateMock);
+            expect(props.canReadRoles).toEqual(false);
+
+            adminStateMock = mockAdminState({auth: mockAuthState({canReadRoles: true})});
+            props = mapStateToProps(adminStateMock);
             expect(props.canReadRoles).toEqual(true);
         }
     );
 
     it(
-        "maps canReadRoles property to false if user does not have '*roles.read' permission",
+        "gets canWriteRoles property from auth state",
         () => {
-            const adminStateMock = mockAdminState();
-            const props = mapStateToProps(adminStateMock);
-            expect(props.canReadRoles).toEqual(false);
-        }
-    );
-
-    it(
-        "maps canWriteRoles property to true if user has '*roles.write' permission",
-        () => {
-            const adminStateMock = mockAdminState({auth: mockAuthState({permissions: ["*/roles.write"]})});
-            const props = mapStateToProps(adminStateMock);
-            expect(props.canWriteRoles).toEqual(true);
-        }
-    );
-
-    it(
-        "maps canWriteRoles property to false if user does not have '*roles.write' permission",
-        () => {
-            const adminStateMock = mockAdminState();
-            const props = mapStateToProps(adminStateMock);
+            let adminStateMock = mockAdminState({auth: mockAuthState({canWriteRoles: false})});
+            let props = mapStateToProps(adminStateMock);
             expect(props.canWriteRoles).toEqual(false);
+
+            adminStateMock = mockAdminState({auth: mockAuthState({canWriteRoles: true})});
+            props = mapStateToProps(adminStateMock);
+            expect(props.canWriteRoles).toEqual(true);
         }
     );
 

--- a/app/src/test/mocks/mockStates.ts
+++ b/app/src/test/mocks/mockStates.ts
@@ -31,11 +31,19 @@ export const mockAuthStateObject: AuthState = {
     loggedIn: true,
     username: 'test.user',
     bearerToken: 'TEST-TOKEN',
-    permissions: [],
     modellingGroups: [],
     isAccountActive: true,
     isModeller: false,
-    canUploadCoverage: false
+    canUploadCoverage: false,
+    canDownloadCoverage: false,
+    canViewGroups: false,
+    canViewTouchstones: false,
+    canViewUsers: false,
+    canReadRoles: false,
+    canWriteRoles: false,
+    canCreateUsers: false,
+    canCreateModellingGroups: false,
+    canManageGroupMembers: false
 };
 
 export const mockAuthState = (props?: RecursivePartial<AuthState>) => {

--- a/app/src/test/shared/reducers/AuthReducersTests.ts
+++ b/app/src/test/shared/reducers/AuthReducersTests.ts
@@ -168,7 +168,7 @@ describe ('loadAuthState tests', () => {
     });
 
     it('sets canCreateModellingGroups if users create permission present', () => {
-        expect(loadAuthStateWithPermission("*/users.create").canCreateModellingGroups).toBe(true);
+        expect(loadAuthStateWithPermission("*/modelling-groups.write").canCreateModellingGroups).toBe(true);
     });
 
     it('sets canManageGroupMembers if modelling groups manage members permission present', () => {

--- a/app/src/test/shared/reducers/AuthReducersTests.ts
+++ b/app/src/test/shared/reducers/AuthReducersTests.ts
@@ -9,10 +9,18 @@ const testAuthData: AuthState = {
     loggedIn: false,
     username: 'test.user',
     bearerToken: 'testtoken',
-    permissions: [],
     isAccountActive: true,
     isModeller: false,
-    canUploadCoverage: false
+    canUploadCoverage: false,
+    canDownloadCoverage: false,
+    canViewGroups: false,
+    canViewTouchstones: false,
+    canViewUsers: false,
+    canReadRoles: false,
+    canWriteRoles: false,
+    canCreateUsers: false,
+    canCreateModellingGroups: false,
+    canManageGroupMembers: false
 };
 
 describe('Auth reducer tests', () => {
@@ -77,9 +85,21 @@ describe ('loadAuthState tests', () => {
         expect(result.username).toEqual("testUser");
         expect(result.loggedIn).toEqual(true);
         expect(result.bearerToken).toEqual("testToken");
-        expect(result.permissions).toEqual(["perm1", "perm2"]);
         expect(result.modellingGroups).toEqual(["group1", "group2"]);
-        expect(result.canUploadCoverage).toBe(false);
+        const expectAllFalse = (...params: boolean[]) =>
+            params.forEach(value => expect(value).toBe(false));
+        expectAllFalse(
+            result.canDownloadCoverage,
+            result.canUploadCoverage,
+            result.canViewGroups,
+            result.canViewTouchstones,
+            result.canViewUsers,
+            result.canReadRoles,
+            result.canWriteRoles,
+            result.canCreateUsers,
+            result.canCreateModellingGroups,
+            result.canManageGroupMembers
+        );
     });
 
     it('sets isAccountActive correctly', () => {
@@ -108,11 +128,50 @@ describe ('loadAuthState tests', () => {
         expect(nonModeller.isModeller).toEqual(false);
     });
 
-    it('sets canUploadCoverage if coverage write permission present', () => {
-        const result = loadAuthState({
+    const loadAuthStateWithPermission = (permission: string) => {
+        return loadAuthState({
             ...basicOptions,
-            permissions: ["*/coverage.write", "perm1", "perm2"]
+            permissions: [...basicOptions.permissions, permission]
         });
-        expect(result.canUploadCoverage).toBe(true);
+    };
+
+    it('sets canUploadCoverage if coverage write permission present', () => {
+        expect(loadAuthStateWithPermission("*/coverage.write").canUploadCoverage).toBe(true);
+    });
+
+    it('sets canDownloadCoverage if coverage read permission present', () => {
+        expect(loadAuthStateWithPermission( "*/coverage.write").canUploadCoverage).toBe(true);
+    });
+
+    it('sets canViewGroups if modelling groups read permission present', () => {
+        expect(loadAuthStateWithPermission("*/modelling-groups.read").canViewGroups).toBe(true);
+    });
+
+    it('sets canViewTouchstones if touchstones read permission present', () => {
+        expect(loadAuthStateWithPermission("*/touchstones.read").canViewTouchstones).toBe(true);
+    });
+
+    it('sets canViewUsers if users read permission present', () => {
+        expect(loadAuthStateWithPermission("*/users.read").canViewUsers).toBe(true);
+    });
+
+    it('sets canReadRoles if roles read permission present', () => {
+        expect(loadAuthStateWithPermission("*/roles.read").canReadRoles).toBe(true);
+    });
+
+    it('sets canWriteRoles if roles write permission present', () => {
+        expect(loadAuthStateWithPermission("*/roles.write").canWriteRoles).toBe(true);
+    });
+
+    it('sets canCreateUsers if users create permission present', () => {
+        expect(loadAuthStateWithPermission("*/users.create").canCreateUsers).toBe(true);
+    });
+
+    it('sets canCreateModellingGroups if users create permission present', () => {
+        expect(loadAuthStateWithPermission("*/users.create").canCreateModellingGroups).toBe(true);
+    });
+
+    it('sets canManageGroupMembers if modelling groups manage members permission present', () => {
+        expect(loadAuthStateWithPermission("*/modelling-groups.manage-members").canManageGroupMembers).toBe(true);
     });
 });

--- a/app/src/test/shared/reducers/AuthReducersTests.ts
+++ b/app/src/test/shared/reducers/AuthReducersTests.ts
@@ -140,7 +140,7 @@ describe ('loadAuthState tests', () => {
     });
 
     it('sets canDownloadCoverage if coverage read permission present', () => {
-        expect(loadAuthStateWithPermission( "*/coverage.write").canUploadCoverage).toBe(true);
+        expect(loadAuthStateWithPermission( "*/coverage.read").canDownloadCoverage).toBe(true);
     });
 
     it('sets canViewGroups if modelling groups read permission present', () => {


### PR DESCRIPTION
Remove permissions as a property on auth state, and put all knowledge of individual permissions and the abilities they confer into the state, and use these properties in the components. 

This is preparatory for using these same properties in the router to hide pages from users who should not have access to them 