### PR TITLE
vimc-4545 Users without permission should get 404s on user list and details pages

### DIFF
--- a/app/src/main/admin/components/AdminRouter.tsx
+++ b/app/src/main/admin/components/AdminRouter.tsx
@@ -29,6 +29,7 @@ interface AdminRouterProps {
     loggedIn: boolean;
     history: History;
     canUploadCoverage: boolean;
+    canViewUsers: boolean;
 }
 
 export const AdminRouterComponent: React.FunctionComponent<AdminRouterProps> = (props: AdminRouterProps) => {
@@ -51,8 +52,12 @@ export const AdminRouterComponent: React.FunctionComponent<AdminRouterProps> = (
             <Route exact path="/touchstones/:touchstoneId/:touchstoneVersionId/coverage/" component={CoveragePage}/>
         }
         <Route exact path="/touchstones/:touchstoneId/:touchstoneVersionId/coverage/coverage-variables/" component={CoverageVariablesPage}/>
-        <Route exact path="/users/" component={UsersListPage}/>
-        <Route exact path="/users/:username/" component={UserDetailsPage}/>
+        { props.canViewUsers &&
+            <Route exact path="/users/" component={UsersListPage}/>
+        }
+        { props.canViewUsers &&
+            <Route exact path="/users/:username/" component={UserDetailsPage}/>
+        }
         <Route component={AdminNoRouteFoundPage}/>
     </Switch>;
 
@@ -74,7 +79,8 @@ export const mapStateToProps = (state: AdminAppState, props: Partial<AdminRouter
     return {
         history: props.history,
         loggedIn: state.auth.loggedIn,
-        canUploadCoverage: state.auth.canUploadCoverage
+        canUploadCoverage: state.auth.canUploadCoverage,
+        canViewUsers: state.auth.canViewUsers
     }
 };
 

--- a/app/src/test/admin/components/AdminRouterTests.tsx
+++ b/app/src/test/admin/components/AdminRouterTests.tsx
@@ -14,6 +14,8 @@ import {createMockAdminStore} from "../../mocks/mockStore";
 import {RecursivePartial} from "../../mocks/mockStates";
 import {AdminAppState} from "../../../main/admin/reducers/adminAppReducers";
 import {CoveragePage} from "../../../main/admin/components/Touchstones/Coverage/CoveragePage";
+import {UsersListPage} from "../../../main/admin/components/Users/List/UsersListPage";
+import {UserDetailsPage} from "../../../main/admin/components/Users/SingleUser/UserDetailsPage";
 
 describe("AdminRouter", () => {
 
@@ -48,5 +50,23 @@ describe("AdminRouter", () => {
 
         rendered = renderComponent({auth: {loggedIn: true, canUploadCoverage: false}}, coverageRoute);
         expect(rendered.find(CoveragePage)).toHaveLength(0);
+    });
+
+    it("includes users page only when current user can view users", () => {
+        const usersRoute = "/users/";
+        let rendered = renderComponent({auth: {loggedIn: true, canViewUsers: true}}, usersRoute);
+        expect(rendered.find(UsersListPage)).toHaveLength(1);
+
+        rendered = renderComponent({auth: {loggedIn: true, canViewUsers: false}}, usersRoute);
+        expect(rendered.find(UsersListPage)).toHaveLength(0);
+    });
+
+    it("includes user page only when current user can view users", () => {
+        const userRoute = "/users/test-user/";
+        let rendered = renderComponent({auth: {loggedIn: true, canViewUsers: true}}, userRoute);
+        expect(rendered.find(UserDetailsPage)).toHaveLength(1);
+
+        rendered = renderComponent({auth: {loggedIn: true, canViewUsers: false}}, userRoute);
+        expect(rendered.find(UsersListPage)).toHaveLength(0);
     });
 });

--- a/app/src/test/admin/components/AdminRouterTests.tsx
+++ b/app/src/test/admin/components/AdminRouterTests.tsx
@@ -67,6 +67,6 @@ describe("AdminRouter", () => {
         expect(rendered.find(UserDetailsPage)).toHaveLength(1);
 
         rendered = renderComponent({auth: {loggedIn: true, canViewUsers: false}}, userRoute);
-        expect(rendered.find(UsersListPage)).toHaveLength(0);
+        expect(rendered.find(UserDetailsPage)).toHaveLength(0);
     });
 });


### PR DESCRIPTION
Does not include these pages in the router when user does not have */users.read permission. 

Can be tested manually by commenting out `$here/cli.sh addRole test.user admin` in the script `add-test-accounts-for-integration-tests.sh` before running the dependencies - browsing to these pages should now show a 'Page not found' page rather than 'You do not have sufficient permissions' errors and endless spinner. 