### PR TITLE
vimc-4546 Add mq and flower to docker compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,14 +28,10 @@ services:
       - $ROOT/demo:/orderly
       - $ROOT/config/orderlyweb:/etc/orderly/web
   mq:
-    image: redis
-    ports:
-      - "6379:6379"
+    image: redis:6
   flower:
     image: mher/flower:0.9.5
-    ports:
-      - "5555:5555"
     environment:
       - FLOWER_PORT=5555
-      - CELERY_BROKER_URL=redis://guest@montagu_mq_1//
-      - CELERY_RESULT_BACKEND=redis://guest@montagu_mq_1/0
+      - CELERY_BROKER_URL=redis://guest@mq//
+      - CELERY_RESULT_BACKEND=redis://guest@mq/0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,3 +27,15 @@ services:
     volumes:
       - $ROOT/demo:/orderly
       - $ROOT/config/orderlyweb:/etc/orderly/web
+  mq:
+    image: redis
+    ports:
+      - "6379:6379"
+  flower:
+    image: mher/flower:0.9.5
+    ports:
+      - "5555:5555"
+    environment:
+      - FLOWER_PORT=5555
+      - CELERY_BROKER_URL=redis://guest@montagu_mq_1//
+      - CELERY_RESULT_BACKEND=redis://guest@montagu_mq_1/0


### PR DESCRIPTION
Adds redis message queue and flower to docker compose for dev dependencies. Without them, an error is shown on burden estimate upload when the API tries to put a message on the queue to kick off a diagnostic report. 

This error probably shouldn't be shown to user anyway as it indicates a problem with montagu infrastucture rather than a problem with the user's upload. This would be a fix in API. But this helps with testing for now.

Test this fix by uploading the burden estimates csv file in the attached zip in the contribution portal, for op-2017-2 touchstone, routine scenario. No error should be shown.

[dummyDEVcentral-burden-template.op-2017-2.description (1).zip](https://github.com/vimc/montagu-webapps/files/5888385/dummyDEVcentral-burden-template.op-2017-2.description.1.zip)

