### PR TITLE
VIMC-4734 Add comments to responsibilities

### DIFF
--- a/app/scripts/run-dependencies.sh
+++ b/app/scripts/run-dependencies.sh
@@ -16,7 +16,7 @@ then
   echo "Orderly demo folder already exists, not re-creating it."
 else
   docker pull $ORDERLY_IMAGE
-  docker run --rm --entrypoint create_orderly_demo.sh -v "$ROOT:/orderly" -u $UID -w /orderly $ORDERLY_IMAGE .
+  docker run --rm --entrypoint create_orderly_demo.sh -v "$ROOT:/orderly" -u $UID -w /orderly -e HOME=/tmp $ORDERLY_IMAGE .
 fi
 
 # migrate to add orderlyweb tables

--- a/app/src/integrationTests/AdminIntegrationTests.tsx
+++ b/app/src/integrationTests/AdminIntegrationTests.tsx
@@ -376,6 +376,14 @@ class AdminIntegrationTests extends IntegrationTestSuite {
             // just check it's the format we're expecting
             expect(headers).toEqual("\"vaccine\", \"country\", \"activity_type\", \"gavi_support\", \"year\", \"age_first\", \"age_last\", \"gender\", \"target\", \"coverage\", \"subnational\"")
         })
+
+        it("can annotate responsibility", async() => {
+            await addResponsibilities(this.db);
+            const touchstoneService = new TouchstonesService(this.store.dispatch, this.store.getState);
+            const result = await touchstoneService
+                .addResponsibilityComment(touchstoneVersionId, "g1", scenarioId, "comment 1");
+            expect(result).toEqual("OK")
+        })
     }
 }
 

--- a/app/src/main/admin/actions/adminTouchstoneActionCreators.ts
+++ b/app/src/main/admin/actions/adminTouchstoneActionCreators.ts
@@ -1,9 +1,17 @@
 import {Dispatch} from "redux";
-import {ResponsibilitySetWithExpectations, Touchstone} from "../../shared/models/Generated";
+import {
+    ResponsibilitySetWithComments,
+    ResponsibilitySetWithExpectations,
+    Touchstone
+} from "../../shared/models/Generated";
 import {AdminAppState} from "../reducers/adminAppReducers";
 import {TouchstonesService} from "../../shared/services/TouchstonesService";
 import {
-    AllTouchstonesFetched, NewTouchstoneCreated, ResponsibilitiesForTouchstoneVersionFetched, SetCreateTouchstoneError,
+    AllTouchstonesFetched,
+    NewTouchstoneCreated,
+    ResponsibilitiesForTouchstoneVersionFetched,
+    ResponsibilityCommentsForTouchstoneVersionFetched,
+    SetCreateTouchstoneError,
     TouchstoneTypes
 } from "../../shared/actionTypes/TouchstonesTypes";
 import {TouchstoneCreation} from "../components/Touchstones/Create/CreateTouchstoneForm";
@@ -27,6 +35,28 @@ export const adminTouchstoneActionCreators = {
                 type: TouchstoneTypes.RESPONSIBILITIES_FOR_TOUCHSTONE_VERSION_FETCHED,
                 data: responsibilitySets
             } as ResponsibilitiesForTouchstoneVersionFetched);
+        }
+    },
+
+    getResponsibilityCommentsForTouchstoneVersion(touchstoneVersion: string) {
+        return async (dispatch: Dispatch<AdminAppState>, getState: () => AdminAppState) => {
+                const responsibilityCommentSets: ResponsibilitySetWithComments[] = await (new TouchstonesService(dispatch, getState))
+                        .getResponsibilityCommentsForTouchstoneVersion(touchstoneVersion);
+                dispatch({
+                        type: TouchstoneTypes.RESPONSIBILITY_COMMENTS_FOR_TOUCHSTONE_VERSION_FETCHED,
+                        data: responsibilityCommentSets
+                } as ResponsibilityCommentsForTouchstoneVersionFetched);
+            }
+    },
+
+    addResponsibilityComment(touchstoneVersion: string, modellingGroupId: string, scenarioId: string, comment: string) {
+        return async (dispatch: Dispatch<AdminAppState>, getState: () => AdminAppState) => {
+            const service = new TouchstonesService(dispatch, getState);
+            const result = await service.addResponsibilityComment(touchstoneVersion, modellingGroupId, scenarioId, comment);
+            if (result) {
+                service.clearCacheForTouchstoneResponsibilityComments(touchstoneVersion);
+                dispatch(this.getResponsibilityCommentsForTouchstoneVersion(touchstoneVersion));
+            }
         }
     },
 

--- a/app/src/main/admin/actions/adminTouchstoneActionCreators.ts
+++ b/app/src/main/admin/actions/adminTouchstoneActionCreators.ts
@@ -62,7 +62,6 @@ export const adminTouchstoneActionCreators = {
             const service = new TouchstonesService(dispatch, getState);
             const result = await service.addResponsibilityComment(touchstoneVersion, modellingGroupId, scenarioId, comment);
             if (result) {
-                dispatch(this.setCurrentTouchstoneResponsibility(null));
                 service.clearCacheForTouchstoneResponsibilityComments(touchstoneVersion);
                 dispatch(this.getResponsibilityCommentsForTouchstoneVersion(touchstoneVersion));
             }

--- a/app/src/main/admin/actions/adminTouchstoneActionCreators.ts
+++ b/app/src/main/admin/actions/adminTouchstoneActionCreators.ts
@@ -15,6 +15,7 @@ import {
     TouchstoneTypes
 } from "../../shared/actionTypes/TouchstonesTypes";
 import {TouchstoneCreation} from "../components/Touchstones/Create/CreateTouchstoneForm";
+import {AnnotatedResponsibility} from "../models/AnnotatedResponsibility";
 
 export const adminTouchstoneActionCreators = {
     getAllTouchstones() {
@@ -38,6 +39,13 @@ export const adminTouchstoneActionCreators = {
         }
     },
 
+    setCurrentTouchstoneResponsibility(responsibility: AnnotatedResponsibility) {
+        return {
+            type: TouchstoneTypes.SET_CURRENT_TOUCHSTONE_RESPONSIBILITY,
+            data: responsibility
+        };
+    },
+
     getResponsibilityCommentsForTouchstoneVersion(touchstoneVersion: string) {
         return async (dispatch: Dispatch<AdminAppState>, getState: () => AdminAppState) => {
                 const responsibilityCommentSets: ResponsibilitySetWithComments[] = await (new TouchstonesService(dispatch, getState))
@@ -54,6 +62,7 @@ export const adminTouchstoneActionCreators = {
             const service = new TouchstonesService(dispatch, getState);
             const result = await service.addResponsibilityComment(touchstoneVersion, modellingGroupId, scenarioId, comment);
             if (result) {
+                dispatch(this.setCurrentTouchstoneResponsibility(null));
                 service.clearCacheForTouchstoneResponsibilityComments(touchstoneVersion);
                 dispatch(this.getResponsibilityCommentsForTouchstoneVersion(touchstoneVersion));
             }

--- a/app/src/main/admin/actions/pages/TouchstoneResponsibilityPageActionCreators.ts
+++ b/app/src/main/admin/actions/pages/TouchstoneResponsibilityPageActionCreators.ts
@@ -24,7 +24,8 @@ class TouchstoneResponsibilitiesPageActionCreators
         return async (dispatch: Dispatch<AdminAppState>, getState: () => AdminAppState) => {
             const touchstones = getState().touchstones.touchstones;
             dispatch(touchstonesActionCreators.setCurrentTouchstoneVersion(params.touchstoneVersionId, touchstones));
-            dispatch(adminTouchstoneActionCreators.getResponsibilitiesForTouchstoneVersion(params.touchstoneVersionId))
+            dispatch(adminTouchstoneActionCreators.getResponsibilitiesForTouchstoneVersion(params.touchstoneVersionId));
+            dispatch(adminTouchstoneActionCreators.getResponsibilityCommentsForTouchstoneVersion(params.touchstoneVersionId));
         }
     }
 

--- a/app/src/main/admin/components/Touchstones/SingleTouchstoneVersion/ResponsibilitiesPage.tsx
+++ b/app/src/main/admin/components/Touchstones/SingleTouchstoneVersion/ResponsibilitiesPage.tsx
@@ -6,46 +6,110 @@ import {Dispatch} from "redux";
 import {connect} from "react-redux";
 import {touchstoneResponsibilitiesPageActionCreators} from "../../../actions/pages/TouchstoneResponsibilityPageActionCreators";
 import {ResponsibilityList} from "./ResponsibilityList";
-import {ResponsibilitySetWithExpectations} from "../../../../shared/models/Generated";
+import {
+    ResponsibilitySetWithComments,
+    ResponsibilitySetWithExpectations
+} from "../../../../shared/models/Generated";
 import {compose} from "recompose";
 import {TouchstoneVersionPageLocationProps} from "./TouchstoneVersionPage";
+import {ResponsibilityCommentModal} from "./ResponsibilityCommentModal";
+import {adminTouchstoneActionCreators} from "../../../actions/adminTouchstoneActionCreators";
+import {AnnotatedResponsibility} from "../../../models/AnnotatedResponsibility";
 
 export interface ResponsibilitiesPageProps extends PageProperties<TouchstoneVersionPageLocationProps> {
     currentTouchstoneVersionId: string;
-    responsibilitySets: ResponsibilitySetWithExpectations[]
+    responsibilitySets: ResponsibilitySetWithExpectations[];
+    responsibilityComments: ResponsibilitySetWithComments[];
+    addResponsibilityComment: (currentTouchstoneVersion: string, responsibility: AnnotatedResponsibility, comment: string) => void;
 }
 
-export class ResponsibilitiesPageComponent extends React.Component<ResponsibilitiesPageProps> {
+export interface ResponsibilitiesPageState {
+    selectedResponsibility: AnnotatedResponsibility;
+}
+
+export class ResponsibilitiesPageComponent extends React.Component<ResponsibilitiesPageProps, ResponsibilitiesPageState> {
+    constructor(props: ResponsibilitiesPageProps) {
+        super(props);
+        this.state = {
+            selectedResponsibility: null
+        };
+        this.selectResponsibility = this.selectResponsibility.bind(this);
+        this.addResponsibilityComment = this.addResponsibilityComment.bind(this);
+        this.cancelResponsibilityComment = this.cancelResponsibilityComment.bind(this);
+    }
 
     componentDidMount() {
         this.props.onLoad(this.props.match.params)
     }
 
+    selectResponsibility(responsibility: AnnotatedResponsibility) {
+        this.setState({
+            selectedResponsibility: responsibility
+        })
+    }
+
+    addResponsibilityComment(currentTouchstoneVersion: string, responsibility: AnnotatedResponsibility, comment: string) {
+        this.props.addResponsibilityComment(currentTouchstoneVersion, responsibility, comment);
+        this.setState({
+            selectedResponsibility: null
+        })
+    }
+
+    cancelResponsibilityComment() {
+        this.setState({
+            selectedResponsibility: null
+        })
+    }
+
+    toAnnotatedResponsibilities(responsibilitySet: ResponsibilitySetWithExpectations): AnnotatedResponsibility[] {
+        return responsibilitySet.responsibilities.map(r => (
+            {
+                modellingGroup: responsibilitySet.modelling_group_id,
+                comment: this.props.responsibilityComments
+                    .find(e => e.modelling_group_id === responsibilitySet.modelling_group_id)
+                    .responsibilities
+                    .find(e => e.scenario_id === r.scenario.id).comment,
+                ...r
+            }
+        ));
+    }
+
     render(): JSX.Element {
         return <PageArticle title={`Responsibility sets in ${this.props.currentTouchstoneVersionId}`}>
-            {this.props.responsibilitySets.map(s => <div key={s.modelling_group_id}>
+            {this.props.responsibilityComments && this.props.responsibilitySets.map(s => <div key={s.modelling_group_id}>
                 <h4>{s.modelling_group_id} (<span>{s.status}</span>)</h4>
-                <ResponsibilityList responsibilities={s.responsibilities}/>
+                <ResponsibilityList responsibilities={this.toAnnotatedResponsibilities(s)} selectResponsibility={this.selectResponsibility}/>
             </div>)}
+            {this.state.selectedResponsibility &&
+            <ResponsibilityCommentModal responsibility={this.state.selectedResponsibility}
+                                        addResponsibilityComment={this.addResponsibilityComment}
+                                        cancelResponsibilityComment={this.cancelResponsibilityComment}/>
+            }
         </PageArticle>;
     }
 }
-
 
 const mapStateToProps = (state: AdminAppState): Partial<ResponsibilitiesPageProps> => {
     return {
         currentTouchstoneVersionId: state.touchstones.currentTouchstoneVersion ?
             state.touchstones.currentTouchstoneVersion.id : '',
-        responsibilitySets: state.touchstones.currentResponsibilitySets
-
+        responsibilitySets: state.touchstones.currentResponsibilitySets,
+        responsibilityComments: state.touchstones.currentResponsibilityComments
     }
 };
 
 export const mapDispatchToProps = (dispatch: Dispatch<AdminAppState>): Partial<ResponsibilitiesPageProps> => {
     return {
         onLoad: (params: TouchstoneVersionPageLocationProps) =>
-            dispatch(touchstoneResponsibilitiesPageActionCreators.onLoad(params))
-    }
+            dispatch(touchstoneResponsibilitiesPageActionCreators.onLoad(params)),
+        addResponsibilityComment: (currentTouchstoneVersion: string, responsibility: AnnotatedResponsibility, comment: string) =>
+            dispatch(adminTouchstoneActionCreators.addResponsibilityComment(
+                currentTouchstoneVersion,
+                responsibility.modellingGroup,
+                responsibility.scenario.id,
+                comment
+            ))
+    };
 };
 
 export const ResponsibilitiesPage =

--- a/app/src/main/admin/components/Touchstones/SingleTouchstoneVersion/ResponsibilitiesPage.tsx
+++ b/app/src/main/admin/components/Touchstones/SingleTouchstoneVersion/ResponsibilitiesPage.tsx
@@ -13,52 +13,18 @@ import {
 import {compose} from "recompose";
 import {TouchstoneVersionPageLocationProps} from "./TouchstoneVersionPage";
 import {ResponsibilityCommentModal} from "./ResponsibilityCommentModal";
-import {adminTouchstoneActionCreators} from "../../../actions/adminTouchstoneActionCreators";
 import {AnnotatedResponsibility} from "../../../models/AnnotatedResponsibility";
 
 export interface ResponsibilitiesPageProps extends PageProperties<TouchstoneVersionPageLocationProps> {
     currentTouchstoneVersionId: string;
     responsibilitySets: ResponsibilitySetWithExpectations[];
     responsibilityComments: ResponsibilitySetWithComments[];
-    addResponsibilityComment: (currentTouchstoneVersion: string, responsibility: AnnotatedResponsibility, comment: string) => void;
 }
 
-export interface ResponsibilitiesPageState {
-    selectedResponsibility: AnnotatedResponsibility;
-}
-
-export class ResponsibilitiesPageComponent extends React.Component<ResponsibilitiesPageProps, ResponsibilitiesPageState> {
-    constructor(props: ResponsibilitiesPageProps) {
-        super(props);
-        this.state = {
-            selectedResponsibility: null
-        };
-        this.selectResponsibility = this.selectResponsibility.bind(this);
-        this.addResponsibilityComment = this.addResponsibilityComment.bind(this);
-        this.cancelResponsibilityComment = this.cancelResponsibilityComment.bind(this);
-    }
+export class ResponsibilitiesPageComponent extends React.Component<ResponsibilitiesPageProps> {
 
     componentDidMount() {
         this.props.onLoad(this.props.match.params)
-    }
-
-    selectResponsibility(responsibility: AnnotatedResponsibility) {
-        this.setState({
-            selectedResponsibility: responsibility
-        })
-    }
-
-    addResponsibilityComment(currentTouchstoneVersion: string, responsibility: AnnotatedResponsibility, comment: string) {
-        this.props.addResponsibilityComment(currentTouchstoneVersion, responsibility, comment);
-        this.setState({
-            selectedResponsibility: null
-        })
-    }
-
-    cancelResponsibilityComment() {
-        this.setState({
-            selectedResponsibility: null
-        })
     }
 
     toAnnotatedResponsibilities(responsibilitySet: ResponsibilitySetWithExpectations): AnnotatedResponsibility[] {
@@ -76,23 +42,18 @@ export class ResponsibilitiesPageComponent extends React.Component<Responsibilit
 
     render(): JSX.Element {
         return <PageArticle title={`Responsibility sets in ${this.props.currentTouchstoneVersionId}`}>
-            {this.props.responsibilityComments && this.props.responsibilitySets.map(s => <div key={s.modelling_group_id}>
+            {this.props.responsibilityComments.length && this.props.responsibilitySets.map(s => <div key={s.modelling_group_id}>
                 <h4>{s.modelling_group_id} (<span>{s.status}</span>)</h4>
-                <ResponsibilityList responsibilities={this.toAnnotatedResponsibilities(s)} selectResponsibility={this.selectResponsibility}/>
+                <ResponsibilityList responsibilities={this.toAnnotatedResponsibilities(s)}/>
             </div>)}
-            {this.state.selectedResponsibility &&
-            <ResponsibilityCommentModal responsibility={this.state.selectedResponsibility}
-                                        addResponsibilityComment={this.addResponsibilityComment}
-                                        cancelResponsibilityComment={this.cancelResponsibilityComment}/>
-            }
+            <ResponsibilityCommentModal/>
         </PageArticle>;
     }
 }
 
 const mapStateToProps = (state: AdminAppState): Partial<ResponsibilitiesPageProps> => {
     return {
-        currentTouchstoneVersionId: state.touchstones.currentTouchstoneVersion ?
-            state.touchstones.currentTouchstoneVersion.id : '',
+        currentTouchstoneVersionId: state.touchstones.currentTouchstoneVersion ? state.touchstones.currentTouchstoneVersion.id : '',
         responsibilitySets: state.touchstones.currentResponsibilitySets,
         responsibilityComments: state.touchstones.currentResponsibilityComments
     }
@@ -101,14 +62,7 @@ const mapStateToProps = (state: AdminAppState): Partial<ResponsibilitiesPageProp
 export const mapDispatchToProps = (dispatch: Dispatch<AdminAppState>): Partial<ResponsibilitiesPageProps> => {
     return {
         onLoad: (params: TouchstoneVersionPageLocationProps) =>
-            dispatch(touchstoneResponsibilitiesPageActionCreators.onLoad(params)),
-        addResponsibilityComment: (currentTouchstoneVersion: string, responsibility: AnnotatedResponsibility, comment: string) =>
-            dispatch(adminTouchstoneActionCreators.addResponsibilityComment(
-                currentTouchstoneVersion,
-                responsibility.modellingGroup,
-                responsibility.scenario.id,
-                comment
-            ))
+            dispatch(touchstoneResponsibilitiesPageActionCreators.onLoad(params))
     };
 };
 

--- a/app/src/main/admin/components/Touchstones/SingleTouchstoneVersion/ResponsibilityCommentModal.tsx
+++ b/app/src/main/admin/components/Touchstones/SingleTouchstoneVersion/ResponsibilityCommentModal.tsx
@@ -1,0 +1,67 @@
+import * as React from "react";
+import {Button, Input, Modal, ModalBody, ModalFooter, ModalHeader} from "reactstrap";
+import {AdminAppState} from "../../../reducers/adminAppReducers";
+import {compose} from "recompose";
+import {connect} from "react-redux";
+import {AnnotatedResponsibility} from "../../../models/AnnotatedResponsibility";
+
+export interface ResponsibilityCommentModalProps {
+    responsibility: AnnotatedResponsibility;
+    currentTouchstoneVersion: string;
+    addResponsibilityComment: (currentTouchstoneVersion: string, responsibility: AnnotatedResponsibility, comment: string) => void;
+    cancelResponsibilityComment: () => void;
+}
+
+export interface ResponsibilityCommentModalState {
+    commentText: string
+}
+
+export class ResponsibilityCommentModalComponent extends React.Component<ResponsibilityCommentModalProps, ResponsibilityCommentModalState> {
+    constructor(props: ResponsibilityCommentModalProps) {
+        super(props);
+        this.state = {
+            commentText: props.responsibility.comment ? props.responsibility.comment.comment : ""
+        };
+        this.handleChange = this.handleChange.bind(this);
+        this.handleClick = this.handleClick.bind(this);
+    }
+    handleChange(event: React.ChangeEvent<HTMLInputElement>) {
+        this.setState({
+            commentText: event.target.value
+        });
+    }
+    handleClick(event: React.FormEvent<HTMLButtonElement>) {
+        this.props.addResponsibilityComment(this.props.currentTouchstoneVersion, this.props.responsibility, this.state.commentText);
+    }
+    render() {
+        return (
+            <div>
+                <Modal isOpen={true} fade={false} centered={true} size="lg">
+                    <ModalHeader>
+                        Comment for {this.props.currentTouchstoneVersion}, {this.props.responsibility.modellingGroup}, {this.props.responsibility.scenario.description}
+                    </ModalHeader>
+                    <ModalBody>
+                        <Input id="comment" type="textarea" rows={10} value={this.state.commentText} onChange={this.handleChange}/>
+                    </ModalBody>
+                    <ModalFooter>
+                        {this.props.responsibility.comment &&
+                        <span className="text-muted mr-auto">Last updated by {this.props.responsibility.comment.added_by} at {this.props.responsibility.comment.added_on}</span>
+                        }
+                        <Button color="secondary" onClick={this.props.cancelResponsibilityComment}>Close</Button>{' '}
+                        <Button color="primary" onClick={this.handleClick}>Save changes</Button>
+                    </ModalFooter>
+                </Modal>
+            </div>
+        );
+    }
+}
+
+export const mapStateToProps = (state: AdminAppState): Partial<ResponsibilityCommentModalProps> => {
+    return {
+        currentTouchstoneVersion: state.touchstones.currentTouchstoneVersion && state.touchstones.currentTouchstoneVersion.id
+    }
+};
+
+export const ResponsibilityCommentModal = compose(
+    connect(mapStateToProps)
+)(ResponsibilityCommentModalComponent) as React.ComponentClass<Partial<ResponsibilityCommentModalProps>>;

--- a/app/src/main/admin/components/Touchstones/SingleTouchstoneVersion/ResponsibilityCommentModal.tsx
+++ b/app/src/main/admin/components/Touchstones/SingleTouchstoneVersion/ResponsibilityCommentModal.tsx
@@ -35,6 +35,7 @@ export class ResponsibilityCommentModalComponent extends React.Component<Respons
     }
     handleSave() {
         this.props.addResponsibilityComment(this.props.currentTouchstoneVersion, this.props.responsibility, this.state.commentText);
+        this.props.setCurrentTouchstoneResponsibility(null);
     }
     componentWillReceiveProps(nextProps: Readonly<ResponsibilityCommentModalProps>) {
         this.setState({

--- a/app/src/main/admin/components/Touchstones/SingleTouchstoneVersion/ResponsibilityCommentModal.tsx
+++ b/app/src/main/admin/components/Touchstones/SingleTouchstoneVersion/ResponsibilityCommentModal.tsx
@@ -4,12 +4,14 @@ import {AdminAppState} from "../../../reducers/adminAppReducers";
 import {compose} from "recompose";
 import {connect} from "react-redux";
 import {AnnotatedResponsibility} from "../../../models/AnnotatedResponsibility";
+import {Dispatch} from "redux";
+import {adminTouchstoneActionCreators} from "../../../actions/adminTouchstoneActionCreators";
 
 export interface ResponsibilityCommentModalProps {
     responsibility: AnnotatedResponsibility;
     currentTouchstoneVersion: string;
     addResponsibilityComment: (currentTouchstoneVersion: string, responsibility: AnnotatedResponsibility, comment: string) => void;
-    cancelResponsibilityComment: () => void;
+    setCurrentTouchstoneResponsibility: (responsibility: AnnotatedResponsibility) => void;
 }
 
 export interface ResponsibilityCommentModalState {
@@ -20,37 +22,45 @@ export class ResponsibilityCommentModalComponent extends React.Component<Respons
     constructor(props: ResponsibilityCommentModalProps) {
         super(props);
         this.state = {
-            commentText: props.responsibility.comment ? props.responsibility.comment.comment : ""
+            commentText: this.props.responsibility && this.props.responsibility.comment ? this.props.responsibility.comment.comment : ""
         };
-        this.handleChange = this.handleChange.bind(this);
-        this.handleClick = this.handleClick.bind(this);
     }
     handleChange(event: React.ChangeEvent<HTMLInputElement>) {
         this.setState({
             commentText: event.target.value
         });
     }
-    handleClick(event: React.FormEvent<HTMLButtonElement>) {
+    handleCancel() {
+        this.props.setCurrentTouchstoneResponsibility(null);
+    }
+    handleSave() {
         this.props.addResponsibilityComment(this.props.currentTouchstoneVersion, this.props.responsibility, this.state.commentText);
+    }
+    componentWillReceiveProps(nextProps: Readonly<ResponsibilityCommentModalProps>) {
+        this.setState({
+            commentText: nextProps.responsibility && nextProps.responsibility.comment ? nextProps.responsibility.comment.comment : ""
+        });
     }
     render() {
         return (
             <div>
+                {this.props.responsibility &&
                 <Modal isOpen={true} fade={false} centered={true} size="lg">
                     <ModalHeader>
                         Comment for {this.props.currentTouchstoneVersion}, {this.props.responsibility.modellingGroup}, {this.props.responsibility.scenario.description}
                     </ModalHeader>
                     <ModalBody>
-                        <Input id="comment" type="textarea" rows={10} value={this.state.commentText} onChange={this.handleChange}/>
+                        <Input type="textarea" rows={10} value={this.state.commentText} onChange={this.handleChange.bind(this)}/>
                     </ModalBody>
                     <ModalFooter>
                         {this.props.responsibility.comment &&
                         <span className="text-muted mr-auto">Last updated by {this.props.responsibility.comment.added_by} at {this.props.responsibility.comment.added_on}</span>
                         }
-                        <Button color="secondary" onClick={this.props.cancelResponsibilityComment}>Close</Button>{' '}
-                        <Button color="primary" onClick={this.handleClick}>Save changes</Button>
+                        <Button color="secondary" onClick={this.handleCancel.bind(this)}>Close</Button>{' '}
+                        <Button color="primary" onClick={this.handleSave.bind(this)}>Save changes</Button>
                     </ModalFooter>
                 </Modal>
+                }
             </div>
         );
     }
@@ -58,10 +68,25 @@ export class ResponsibilityCommentModalComponent extends React.Component<Respons
 
 export const mapStateToProps = (state: AdminAppState): Partial<ResponsibilityCommentModalProps> => {
     return {
+        responsibility: state.touchstones.currentResponsibility,
         currentTouchstoneVersion: state.touchstones.currentTouchstoneVersion && state.touchstones.currentTouchstoneVersion.id
     }
 };
 
+export const mapDispatchToProps = (dispatch: Dispatch<AdminAppState>): Partial<ResponsibilityCommentModalProps> => {
+    return {
+        addResponsibilityComment: (currentTouchstoneVersion: string, responsibility: AnnotatedResponsibility, comment: string) =>
+            dispatch(adminTouchstoneActionCreators.addResponsibilityComment(
+                currentTouchstoneVersion,
+                responsibility.modellingGroup,
+                responsibility.scenario.id,
+                comment
+            )),
+        setCurrentTouchstoneResponsibility: (responsibility: AnnotatedResponsibility) =>
+            dispatch(adminTouchstoneActionCreators.setCurrentTouchstoneResponsibility(responsibility))
+    };
+};
+
 export const ResponsibilityCommentModal = compose(
-    connect(mapStateToProps)
+    connect(mapStateToProps, mapDispatchToProps)
 )(ResponsibilityCommentModalComponent) as React.ComponentClass<Partial<ResponsibilityCommentModalProps>>;

--- a/app/src/main/admin/components/Touchstones/SingleTouchstoneVersion/ResponsibilityList.tsx
+++ b/app/src/main/admin/components/Touchstones/SingleTouchstoneVersion/ResponsibilityList.tsx
@@ -1,19 +1,10 @@
-import {Responsibility} from "../../../../shared/models/Generated";
 import * as React from "react";
+import {ResponsibilityListItem} from "./ResponsibilityListItem";
+import {AnnotatedResponsibility} from "../../../models/AnnotatedResponsibility";
 
 interface ResponsibilityListProps {
-    responsibilities: Responsibility[]
-}
-
-export class ResponsibilityListItem extends React.Component<Responsibility, undefined> {
-    render() {
-        return <tr>
-            <td>{this.props.scenario.description}</td>
-            <td>{this.props.scenario.disease}</td>
-            <td>{this.props.status}</td>
-            <td>{this.props.current_estimate_set ? this.props.current_estimate_set.uploaded_on: "None"}</td>
-        </tr>;
-    }
+    responsibilities: AnnotatedResponsibility[];
+    selectResponsibility: (responsibility: AnnotatedResponsibility) => void
 }
 
 export const ResponsibilityList: React.FunctionComponent<ResponsibilityListProps> = (props: ResponsibilityListProps) => {
@@ -24,10 +15,11 @@ export const ResponsibilityList: React.FunctionComponent<ResponsibilityListProps
             <th>Disease</th>
             <th>Status</th>
             <th>Latest estimate set</th>
+            <th>Comment</th>
         </tr>
         </thead>
         <tbody>
-        {props.responsibilities.map(r => <ResponsibilityListItem {...r} key={r.scenario.id}/>)}
+        {props.responsibilities.map(r => <ResponsibilityListItem responsibility={r} selectResponsibility={props.selectResponsibility} key={r.scenario.id}/>)}
         </tbody>
     </table>;
 };

--- a/app/src/main/admin/components/Touchstones/SingleTouchstoneVersion/ResponsibilityList.tsx
+++ b/app/src/main/admin/components/Touchstones/SingleTouchstoneVersion/ResponsibilityList.tsx
@@ -4,7 +4,6 @@ import {AnnotatedResponsibility} from "../../../models/AnnotatedResponsibility";
 
 interface ResponsibilityListProps {
     responsibilities: AnnotatedResponsibility[];
-    selectResponsibility: (responsibility: AnnotatedResponsibility) => void
 }
 
 export const ResponsibilityList: React.FunctionComponent<ResponsibilityListProps> = (props: ResponsibilityListProps) => {
@@ -19,7 +18,7 @@ export const ResponsibilityList: React.FunctionComponent<ResponsibilityListProps
         </tr>
         </thead>
         <tbody>
-        {props.responsibilities.map(r => <ResponsibilityListItem responsibility={r} selectResponsibility={props.selectResponsibility} key={r.scenario.id}/>)}
+        {props.responsibilities.map(r => <ResponsibilityListItem responsibility={r} key={r.scenario.id}/>)}
         </tbody>
     </table>;
 };

--- a/app/src/main/admin/components/Touchstones/SingleTouchstoneVersion/ResponsibilityListItem.tsx
+++ b/app/src/main/admin/components/Touchstones/SingleTouchstoneVersion/ResponsibilityListItem.tsx
@@ -1,0 +1,43 @@
+import * as React from "react";
+import {AnnotatedResponsibility} from "../../../models/AnnotatedResponsibility";
+
+export interface ResponsibilityListItemProps {
+    responsibility: AnnotatedResponsibility
+    selectResponsibility: (responsibility: AnnotatedResponsibility) => void
+}
+
+export class ResponsibilityListItem extends React.Component<ResponsibilityListItemProps, undefined> {
+    constructor(props: ResponsibilityListItemProps) {
+        super(props);
+        this.handleClick = this.handleClick.bind(this);
+    }
+
+    handleClick(event: React.MouseEvent<HTMLAnchorElement>) {
+        event.preventDefault();
+        this.props.selectResponsibility(this.props.responsibility);
+    }
+
+    render() {
+        return <tr>
+            <td>{this.props.responsibility.scenario.description}</td>
+            <td>{this.props.responsibility.scenario.disease}</td>
+            <td>{this.props.responsibility.status}</td>
+            <td>{this.props.responsibility.current_estimate_set ? this.props.responsibility.current_estimate_set.uploaded_on : "None"}</td>
+            <td>
+                <div style={{
+                    display: "table-cell",
+                    width: "100%",
+                    maxWidth: "20em",
+                    whiteSpace: "nowrap",
+                    overflow: "hidden",
+                    textOverflow: "ellipsis"
+                }} title={this.props.responsibility.comment && this.props.responsibility.comment.comment}>
+                    {this.props.responsibility.comment && this.props.responsibility.comment.comment}
+                </div>
+                <div style={{display: "table-cell", textAlign: "right"}}>
+                    <a href="#" className="small" style={{marginLeft: "2em"}} onClick={this.handleClick}>Edit</a>
+                </div>
+            </td>
+        </tr>;
+    }
+}

--- a/app/src/main/admin/components/Touchstones/SingleTouchstoneVersion/ResponsibilityListItem.tsx
+++ b/app/src/main/admin/components/Touchstones/SingleTouchstoneVersion/ResponsibilityListItem.tsx
@@ -1,20 +1,21 @@
 import * as React from "react";
 import {AnnotatedResponsibility} from "../../../models/AnnotatedResponsibility";
+import {Dispatch} from "redux";
+import {AdminAppState} from "../../../reducers/adminAppReducers";
+import {adminTouchstoneActionCreators} from "../../../actions/adminTouchstoneActionCreators";
+import {compose} from "recompose";
+import {connect} from "react-redux";
 
 export interface ResponsibilityListItemProps {
-    responsibility: AnnotatedResponsibility
-    selectResponsibility: (responsibility: AnnotatedResponsibility) => void
+    responsibility: AnnotatedResponsibility;
+    setCurrentTouchstoneResponsibility: (responsibility: AnnotatedResponsibility) => void;
 }
 
-export class ResponsibilityListItem extends React.Component<ResponsibilityListItemProps, undefined> {
-    constructor(props: ResponsibilityListItemProps) {
-        super(props);
-        this.handleClick = this.handleClick.bind(this);
-    }
+export class ResponsibilityListItemComponent extends React.Component<ResponsibilityListItemProps> {
 
     handleClick(event: React.MouseEvent<HTMLAnchorElement>) {
         event.preventDefault();
-        this.props.selectResponsibility(this.props.responsibility);
+        this.props.setCurrentTouchstoneResponsibility(this.props.responsibility);
     }
 
     render() {
@@ -35,9 +36,20 @@ export class ResponsibilityListItem extends React.Component<ResponsibilityListIt
                     {this.props.responsibility.comment && this.props.responsibility.comment.comment}
                 </div>
                 <div style={{display: "table-cell", textAlign: "right"}}>
-                    <a href="#" className="small" style={{marginLeft: "2em"}} onClick={this.handleClick}>Edit</a>
+                    <a href="#" className="small" style={{marginLeft: "2em"}} onClick={this.handleClick.bind(this)}>Edit</a>
                 </div>
             </td>
         </tr>;
     }
 }
+
+export const mapDispatchToProps = (dispatch: Dispatch<AdminAppState>): Partial<ResponsibilityListItemProps> => {
+    return {
+        setCurrentTouchstoneResponsibility: (responsibility: AnnotatedResponsibility) =>
+            dispatch(adminTouchstoneActionCreators.setCurrentTouchstoneResponsibility(responsibility))
+    };
+};
+
+export const ResponsibilityListItem = compose(
+    connect(state => state, mapDispatchToProps))
+(ResponsibilityListItemComponent) as React.ComponentClass<Partial<ResponsibilityListItemProps>>;

--- a/app/src/main/admin/models/AnnotatedResponsibility.ts
+++ b/app/src/main/admin/models/AnnotatedResponsibility.ts
@@ -1,0 +1,6 @@
+import {Responsibility, ResponsibilityComment} from "../../shared/models/Generated";
+
+export interface AnnotatedResponsibility extends Responsibility {
+    modellingGroup: string;
+    comment?: ResponsibilityComment;
+}

--- a/app/src/main/admin/reducers/adminTouchstoneReducer.ts
+++ b/app/src/main/admin/reducers/adminTouchstoneReducer.ts
@@ -1,10 +1,12 @@
 import {
-    ErrorInfo, ResponsibilitySetWithComments,
+    ErrorInfo,
+    ResponsibilitySetWithComments,
     ResponsibilitySetWithExpectations,
     Touchstone,
     TouchstoneVersion
 } from "../../shared/models/Generated";
 import {TouchstonesAction, TouchstoneTypes} from "../../shared/actionTypes/TouchstonesTypes";
+import {AnnotatedResponsibility} from "../models/AnnotatedResponsibility";
 
 export interface AdminTouchstoneState {
     touchstones: Touchstone[];
@@ -12,6 +14,7 @@ export interface AdminTouchstoneState {
     currentTouchstoneVersion: TouchstoneVersion;
     currentResponsibilitySets: ResponsibilitySetWithExpectations[];
     currentResponsibilityComments: ResponsibilitySetWithComments[];
+    currentResponsibility: AnnotatedResponsibility;
     createTouchstoneErrors: ErrorInfo[]
 }
 
@@ -21,6 +24,7 @@ export const adminTouchstonesInitialState: AdminTouchstoneState = {
     currentTouchstoneVersion: null,
     currentResponsibilitySets: [],
     currentResponsibilityComments: [],
+    currentResponsibility: null,
     createTouchstoneErrors: []
 };
 export const adminTouchstoneReducer
@@ -36,6 +40,8 @@ export const adminTouchstoneReducer
             return {...state, currentResponsibilitySets: action.data};
         case TouchstoneTypes.RESPONSIBILITY_COMMENTS_FOR_TOUCHSTONE_VERSION_FETCHED:
             return {...state, currentResponsibilityComments: action.data};
+        case TouchstoneTypes.SET_CURRENT_TOUCHSTONE_RESPONSIBILITY:
+            return {...state, currentResponsibility: action.data};
         case TouchstoneTypes.NEW_TOUCHSTONE_CREATED:
             return {...state, touchstones: [...state.touchstones, action.data]};
         case TouchstoneTypes.SET_CREATE_TOUCHSTONE_ERROR:

--- a/app/src/main/admin/reducers/adminTouchstoneReducer.ts
+++ b/app/src/main/admin/reducers/adminTouchstoneReducer.ts
@@ -1,5 +1,5 @@
 import {
-    ErrorInfo,
+    ErrorInfo, ResponsibilitySetWithComments,
     ResponsibilitySetWithExpectations,
     Touchstone,
     TouchstoneVersion
@@ -11,6 +11,7 @@ export interface AdminTouchstoneState {
     currentTouchstone: Touchstone;
     currentTouchstoneVersion: TouchstoneVersion;
     currentResponsibilitySets: ResponsibilitySetWithExpectations[];
+    currentResponsibilityComments: ResponsibilitySetWithComments[];
     createTouchstoneErrors: ErrorInfo[]
 }
 
@@ -19,6 +20,7 @@ export const adminTouchstonesInitialState: AdminTouchstoneState = {
     currentTouchstone: null,
     currentTouchstoneVersion: null,
     currentResponsibilitySets: [],
+    currentResponsibilityComments: [],
     createTouchstoneErrors: []
 };
 export const adminTouchstoneReducer
@@ -32,6 +34,8 @@ export const adminTouchstoneReducer
             return {...state, currentTouchstoneVersion: action.data};
         case TouchstoneTypes.RESPONSIBILITIES_FOR_TOUCHSTONE_VERSION_FETCHED:
             return {...state, currentResponsibilitySets: action.data};
+        case TouchstoneTypes.RESPONSIBILITY_COMMENTS_FOR_TOUCHSTONE_VERSION_FETCHED:
+            return {...state, currentResponsibilityComments: action.data};
         case TouchstoneTypes.NEW_TOUCHSTONE_CREATED:
             return {...state, touchstones: [...state.touchstones, action.data]};
         case TouchstoneTypes.SET_CREATE_TOUCHSTONE_ERROR:

--- a/app/src/main/shared/actionTypes/TouchstonesTypes.ts
+++ b/app/src/main/shared/actionTypes/TouchstonesTypes.ts
@@ -5,11 +5,13 @@ import {
     Touchstone,
     TouchstoneVersion
 } from "../models/Generated";
+import {AnnotatedResponsibility} from "../../admin/models/AnnotatedResponsibility";
 
 export enum TouchstoneTypes {
     ALL_TOUCHSTONES_FETCHED = "ALL_TOUCHSTONES_FETCHED",
     RESPONSIBILITIES_FOR_TOUCHSTONE_VERSION_FETCHED = "RESPONSIBILITIES_FOR_TOUCHSTONE_VERSION_FETCHED",
     RESPONSIBILITY_COMMENTS_FOR_TOUCHSTONE_VERSION_FETCHED = "RESPONSIBILITY_COMMENTS_FOR_TOUCHSTONE_VERSION_FETCHED",
+    SET_CURRENT_TOUCHSTONE_RESPONSIBILITY = "SET_CURRENT_TOUCHSTONE_RESPONSIBILITY",
     TOUCHSTONES_FETCHED_FOR_GROUP = "TOUCHSTONES_FETCHED_FOR_GROUP",
     SET_CURRENT_TOUCHSTONE_VERSION = "SET_CURRENT_TOUCHSTONE_VERSION",
     NEW_TOUCHSTONE_CREATED = "NEW_TOUCHSTONE_CREATED",
@@ -47,6 +49,11 @@ export interface ResponsibilityCommentsForTouchstoneVersionFetched {
     data: ResponsibilitySetWithComments[];
 }
 
+export interface SetCurrentTouchstoneResponsibility {
+    type: TouchstoneTypes.SET_CURRENT_TOUCHSTONE_RESPONSIBILITY;
+    data: AnnotatedResponsibility;
+}
+
 export interface NewTouchstoneCreated {
     type: TouchstoneTypes.NEW_TOUCHSTONE_CREATED;
     data: Touchstone;
@@ -64,5 +71,6 @@ export type TouchstonesAction =
     | SetCurrentTouchstoneVersion
     | ResponsibilitiesForTouchstoneVersionFetched
     | ResponsibilityCommentsForTouchstoneVersionFetched
+    | SetCurrentTouchstoneResponsibility
     | NewTouchstoneCreated
     | SetCreateTouchstoneError

--- a/app/src/main/shared/actionTypes/TouchstonesTypes.ts
+++ b/app/src/main/shared/actionTypes/TouchstonesTypes.ts
@@ -1,8 +1,15 @@
-import {ErrorInfo, ResponsibilitySetWithExpectations, Touchstone, TouchstoneVersion} from "../models/Generated";
+import {
+    ErrorInfo,
+    ResponsibilitySetWithComments,
+    ResponsibilitySetWithExpectations,
+    Touchstone,
+    TouchstoneVersion
+} from "../models/Generated";
 
 export enum TouchstoneTypes {
     ALL_TOUCHSTONES_FETCHED = "ALL_TOUCHSTONES_FETCHED",
     RESPONSIBILITIES_FOR_TOUCHSTONE_VERSION_FETCHED = "RESPONSIBILITIES_FOR_TOUCHSTONE_VERSION_FETCHED",
+    RESPONSIBILITY_COMMENTS_FOR_TOUCHSTONE_VERSION_FETCHED = "RESPONSIBILITY_COMMENTS_FOR_TOUCHSTONE_VERSION_FETCHED",
     TOUCHSTONES_FETCHED_FOR_GROUP = "TOUCHSTONES_FETCHED_FOR_GROUP",
     SET_CURRENT_TOUCHSTONE_VERSION = "SET_CURRENT_TOUCHSTONE_VERSION",
     NEW_TOUCHSTONE_CREATED = "NEW_TOUCHSTONE_CREATED",
@@ -35,6 +42,11 @@ export interface ResponsibilitiesForTouchstoneVersionFetched {
     data: ResponsibilitySetWithExpectations[];
 }
 
+export interface ResponsibilityCommentsForTouchstoneVersionFetched {
+    type: TouchstoneTypes.RESPONSIBILITY_COMMENTS_FOR_TOUCHSTONE_VERSION_FETCHED;
+    data: ResponsibilitySetWithComments[];
+}
+
 export interface NewTouchstoneCreated {
     type: TouchstoneTypes.NEW_TOUCHSTONE_CREATED;
     data: Touchstone;
@@ -51,5 +63,6 @@ export type TouchstonesAction =
     | SetCurrentTouchstone
     | SetCurrentTouchstoneVersion
     | ResponsibilitiesForTouchstoneVersionFetched
+    | ResponsibilityCommentsForTouchstoneVersionFetched
     | NewTouchstoneCreated
     | SetCreateTouchstoneError

--- a/app/src/main/shared/models/Generated.ts
+++ b/app/src/main/shared/models/Generated.ts
@@ -129,7 +129,7 @@ export interface ResearchModelDetails {
 }
 
 export interface ResponsibilityComment {
-    added_by: string;
+    added_by: string | null;
     added_on: string;
     comment: string;
 }

--- a/app/src/main/shared/models/Generated.ts
+++ b/app/src/main/shared/models/Generated.ts
@@ -128,6 +128,23 @@ export interface ResearchModelDetails {
     modelling_group: string;
 }
 
+export interface ResponsibilityComment {
+    added_by: string;
+    added_on: string;
+    comment: string;
+}
+
+export interface ResponsibilityWithComment {
+    comment: ResponsibilityComment | null;
+    scenario_id: string;
+}
+
+export interface ResponsibilitySetWithComments {
+    modelling_group_id: string;
+    responsibilities: ResponsibilityWithComment[];
+    touchstone_version: string;
+}
+
 export interface Outcome {
     code: string;
     name: string;

--- a/app/src/main/shared/models/Generated.ts
+++ b/app/src/main/shared/models/Generated.ts
@@ -128,8 +128,12 @@ export interface ResearchModelDetails {
     modelling_group: string;
 }
 
+export interface ResponsibilityCommentPayload {
+    comment: string;
+}
+
 export interface ResponsibilityComment {
-    added_by: string | null;
+    added_by: string;
     added_on: string;
     comment: string;
 }

--- a/app/src/main/shared/services/TouchstonesService.ts
+++ b/app/src/main/shared/services/TouchstonesService.ts
@@ -1,5 +1,10 @@
 import {AbstractLocalService} from "./AbstractLocalService";
-import {ResponsibilitySetWithExpectations, ScenarioAndCoverageSets, Touchstone} from "../models/Generated";
+import {
+    ResponsibilitySetWithComments,
+    ResponsibilitySetWithExpectations,
+    ScenarioAndCoverageSets,
+    Touchstone
+} from "../models/Generated";
 
 export class TouchstonesService extends AbstractLocalService {
     getAllTouchstones(): Promise<Touchstone[]> {
@@ -17,6 +22,19 @@ export class TouchstonesService extends AbstractLocalService {
             .get(`/touchstones/${touchstoneVersion}/responsibilities/`);
     }
 
+    getResponsibilityCommentsForTouchstoneVersion(touchstoneVersion: string): Promise<ResponsibilitySetWithComments[]> {
+        return this.setOptions({cacheKey: TouchstonesCacheKeysEnum.responsibilityComments})
+            .get(`/touchstones/${touchstoneVersion}/responsibilities/comments/`);
+    }
+
+    addResponsibilityComment(touchstoneVersion: string, modellingGroupId: string, scenarioId: string, comment: string) {
+        return this.post(`/touchstones/${touchstoneVersion}/responsibilities/comments/?group_id=${modellingGroupId}&scenario_id=${scenarioId}&comment=${encodeURIComponent(comment)}`)
+    }
+
+    clearCacheForTouchstoneResponsibilityComments(touchstoneVersion: string) {
+        return this.clearCache(TouchstonesCacheKeysEnum.responsibilityComments, `/touchstones/${touchstoneVersion}/responsibilities/comments/`);
+    }
+
     getScenariosForTouchstoneVersion(touchstoneVersion: string): Promise<ScenarioAndCoverageSets[]> {
         return this.setOptions({cacheKey: TouchstonesCacheKeysEnum.touchstones})
             .get(`/touchstones/${touchstoneVersion}/scenarios/`);
@@ -25,4 +43,5 @@ export class TouchstonesService extends AbstractLocalService {
 
 export enum TouchstonesCacheKeysEnum {
     touchstones = "touchstones",
+    responsibilityComments = "responsibilityComments",
 }

--- a/app/src/main/shared/services/TouchstonesService.ts
+++ b/app/src/main/shared/services/TouchstonesService.ts
@@ -1,5 +1,6 @@
 import {AbstractLocalService} from "./AbstractLocalService";
 import {
+    ResponsibilityComment,
     ResponsibilitySetWithComments,
     ResponsibilitySetWithExpectations,
     ScenarioAndCoverageSets,
@@ -28,7 +29,11 @@ export class TouchstonesService extends AbstractLocalService {
     }
 
     addResponsibilityComment(touchstoneVersion: string, modellingGroupId: string, scenarioId: string, comment: string) {
-        return this.post(`/touchstones/${touchstoneVersion}/responsibilities/comments/?group_id=${modellingGroupId}&scenario_id=${scenarioId}&comment=${encodeURIComponent(comment)}`)
+        const responsibilityComment: ResponsibilityComment = { comment, added_by: undefined, added_on: undefined };
+        return this.post(
+            `/touchstones/${touchstoneVersion}/responsibilities/${modellingGroupId}/${scenarioId}/comments/`,
+            JSON.stringify(responsibilityComment)
+        );
     }
 
     clearCacheForTouchstoneResponsibilityComments(touchstoneVersion: string) {

--- a/app/src/main/shared/services/TouchstonesService.ts
+++ b/app/src/main/shared/services/TouchstonesService.ts
@@ -1,6 +1,6 @@
 import {AbstractLocalService} from "./AbstractLocalService";
 import {
-    ResponsibilityComment,
+    ResponsibilityCommentPayload,
     ResponsibilitySetWithComments,
     ResponsibilitySetWithExpectations,
     ScenarioAndCoverageSets,
@@ -29,7 +29,7 @@ export class TouchstonesService extends AbstractLocalService {
     }
 
     addResponsibilityComment(touchstoneVersion: string, modellingGroupId: string, scenarioId: string, comment: string) {
-        const responsibilityComment: ResponsibilityComment = { comment, added_by: undefined, added_on: undefined };
+        const responsibilityComment: ResponsibilityCommentPayload = { comment };
         return this.post(
             `/touchstones/${touchstoneVersion}/responsibilities/${modellingGroupId}/${scenarioId}/comments/`,
             JSON.stringify(responsibilityComment)

--- a/app/src/main/shared/styles/bootstrap.scss
+++ b/app/src/main/shared/styles/bootstrap.scss
@@ -33,7 +33,7 @@
 @import "../../../../node_modules/bootstrap/scss/media";
 @import "../../../../node_modules/bootstrap/scss/list-group";
 @import "../../../../node_modules/bootstrap/scss/close";
-// @import "modal";
+@import "../../../../node_modules/bootstrap/scss/modal";
 @import "../../../../node_modules/bootstrap/scss/tooltip";
 @import "../../../../node_modules/bootstrap/scss/popover";
 // @import "carousel";

--- a/app/src/test/admin/actions/AdminTouchstoneActionTests.ts
+++ b/app/src/test/admin/actions/AdminTouchstoneActionTests.ts
@@ -111,7 +111,6 @@ describe("Admin touchstone action tests", () => {
             },
             callActionCreator: () => adminTouchstoneActionCreators.addResponsibilityComment("t1", "m1", "s1", "c"),
             expectTheseActions: [
-                {type: TouchstoneTypes.SET_CURRENT_TOUCHSTONE_RESPONSIBILITY, data: null},
                 {type: TouchstoneTypes.RESPONSIBILITY_COMMENTS_FOR_TOUCHSTONE_VERSION_FETCHED, data: "default_result"}
             ]
         });

--- a/app/src/test/admin/actions/pages/TouchstoneResponsibilitiesPageActionTests.ts
+++ b/app/src/test/admin/actions/pages/TouchstoneResponsibilitiesPageActionTests.ts
@@ -22,12 +22,15 @@ describe("Touchstone responsibility page actions tests", () => {
         const setCurrentStub = sandbox.setStubReduxAction(touchstonesActionCreators, "setCurrentTouchstoneVersion");
         const responsibilitiesStub =
             sandbox.setStubReduxAction(adminTouchstoneActionCreators, "getResponsibilitiesForTouchstoneVersion");
+        const responsibilitiesCommentsStub =
+            sandbox.setStubReduxAction(adminTouchstoneActionCreators, "getResponsibilityCommentsForTouchstoneVersion");
 
         store.dispatch(touchstoneResponsibilitiesPageActionCreators
             .loadData({touchstoneVersionId: "t1", touchstoneId: "whatever"}));
         setTimeout(() => {
             expect(setCurrentStub.mock.calls.length).toBe(1);
             expect(responsibilitiesStub.mock.calls.length).toBe(1);
+            expect(responsibilitiesCommentsStub.mock.calls.length).toBe(1);
             done();
         });
     });

--- a/app/src/test/admin/components/Touchstones/SingleVersion/ResponsibilityCommentModalTests.tsx
+++ b/app/src/test/admin/components/Touchstones/SingleVersion/ResponsibilityCommentModalTests.tsx
@@ -1,0 +1,32 @@
+import {AnnotatedResponsibility} from "../../../../../main/admin/models/AnnotatedResponsibility";
+import {mockModellingGroup, mockResponsibility} from "../../../../mocks/mockModels";
+import {createMockAdminStore} from "../../../../mocks/mockStore";
+import {mount} from "enzyme";
+import {ResponsibilityCommentModal} from "../../../../../main/admin/components/Touchstones/SingleTouchstoneVersion/ResponsibilityCommentModal";
+import * as React from "react";
+
+describe("ResponsibilityCommentModal", () => {
+
+    it("renders modal", () => {
+        const responsibility: AnnotatedResponsibility = {
+            ...mockResponsibility(),
+            modellingGroup: mockModellingGroup().id,
+            comment: {
+                comment: "Lorem ipsum",
+                added_by: "test.user",
+                added_on: "2017-07-13 13:55:29 +0100"
+            }
+        };
+        const store = createMockAdminStore({
+            touchstones: {
+                currentTouchstoneVersion: {id: "touchstone-1"},
+                currentResponsibility: responsibility
+            }
+        });
+        const rendered = mount(<ResponsibilityCommentModal/>, {context: {store}});
+        expect(rendered.find(".modal-title").at(0).text()).toEqual("Comment for touchstone-1, group-2, Description");
+        expect(rendered.find(".modal-body textarea").at(0).props().value).toEqual("Lorem ipsum");
+        expect(rendered.find(".modal-footer span").at(0).text()).toEqual("Last updated by test.user at 2017-07-13 13:55:29 +0100");
+    })
+
+});

--- a/app/src/test/admin/components/Touchstones/SingleVersion/ResponsibilityCommentModalTests.tsx
+++ b/app/src/test/admin/components/Touchstones/SingleVersion/ResponsibilityCommentModalTests.tsx
@@ -1,32 +1,62 @@
-import {AnnotatedResponsibility} from "../../../../../main/admin/models/AnnotatedResponsibility";
-import {mockModellingGroup, mockResponsibility} from "../../../../mocks/mockModels";
+import {
+    mockAnnotatedResponsibility,
+    mockTouchstoneVersion
+} from "../../../../mocks/mockModels";
 import {createMockAdminStore} from "../../../../mocks/mockStore";
 import {mount} from "enzyme";
-import {ResponsibilityCommentModal} from "../../../../../main/admin/components/Touchstones/SingleTouchstoneVersion/ResponsibilityCommentModal";
+import {
+    ResponsibilityCommentModal,
+    ResponsibilityCommentModalComponent
+} from "../../../../../main/admin/components/Touchstones/SingleTouchstoneVersion/ResponsibilityCommentModal";
 import * as React from "react";
+import {mockEvent} from "../../../../mocks/mocks";
 
 describe("ResponsibilityCommentModal", () => {
 
     it("renders modal", () => {
-        const responsibility: AnnotatedResponsibility = {
-            ...mockResponsibility(),
-            modellingGroup: mockModellingGroup().id,
-            comment: {
-                comment: "Lorem ipsum",
-                added_by: "test.user",
-                added_on: "2017-07-13 13:55:29 +0100"
-            }
-        };
         const store = createMockAdminStore({
             touchstones: {
-                currentTouchstoneVersion: {id: "touchstone-1"},
-                currentResponsibility: responsibility
+                currentTouchstoneVersion: mockTouchstoneVersion(),
+                currentResponsibility: mockAnnotatedResponsibility()
             }
         });
         const rendered = mount(<ResponsibilityCommentModal/>, {context: {store}});
-        expect(rendered.find(".modal-title").at(0).text()).toEqual("Comment for touchstone-1, group-2, Description");
+        expect(rendered.find(".modal-title").at(0).text()).toEqual("Comment for touchstone-1, g1, Description");
         expect(rendered.find(".modal-body textarea").at(0).props().value).toEqual("Lorem ipsum");
         expect(rendered.find(".modal-footer span").at(0).text()).toEqual("Last updated by test.user at 2017-07-13 13:55:29 +0100");
+    })
+
+    it("saves comment", () => {
+        const touchstone = mockTouchstoneVersion();
+        const responsibility = mockAnnotatedResponsibility();
+        const submitCallback = jest.fn();
+        const cancelCallback = jest.fn();
+        const rendered = mount(
+            <ResponsibilityCommentModalComponent
+                addResponsibilityComment={submitCallback}
+                setCurrentTouchstoneResponsibility={cancelCallback}
+                responsibility={responsibility}
+                currentTouchstoneVersion={touchstone.id}
+            />
+        );
+        rendered.find(".modal-body textarea").at(0).simulate("change", {target: {value: "Ut enim"}});
+        rendered.find(".btn-primary").simulate("click", mockEvent());
+        expect(submitCallback.mock.calls.length).toEqual(1);
+        expect(submitCallback.mock.calls[0]).toEqual([touchstone.id, responsibility, "Ut enim"]);
+        expect(cancelCallback.mock.calls.length).toEqual(0);
+    })
+
+    it("cancels comment", () => {
+        const touchstone = mockTouchstoneVersion();
+        const responsibility = mockAnnotatedResponsibility();
+        const submitCallback = jest.fn();
+        const cancelCallback = jest.fn();
+        const rendered = mount(<ResponsibilityCommentModalComponent addResponsibilityComment={submitCallback} setCurrentTouchstoneResponsibility={cancelCallback} responsibility={responsibility} currentTouchstoneVersion={touchstone.id}/>);
+        rendered.find(".modal-body textarea").at(0).simulate("change", {target: {value: "Ut enim"}});
+        rendered.find(".btn-secondary").simulate("click", mockEvent());
+        expect(submitCallback.mock.calls.length).toEqual(0);
+        expect(cancelCallback.mock.calls.length).toEqual(1);
+        expect(cancelCallback.mock.calls[0]).toEqual([null]);
     })
 
 });

--- a/app/src/test/admin/components/Touchstones/SingleVersion/ResponsibilityCommentModalTests.tsx
+++ b/app/src/test/admin/components/Touchstones/SingleVersion/ResponsibilityCommentModalTests.tsx
@@ -30,11 +30,11 @@ describe("ResponsibilityCommentModal", () => {
         const touchstone = mockTouchstoneVersion();
         const responsibility = mockAnnotatedResponsibility();
         const submitCallback = jest.fn();
-        const cancelCallback = jest.fn();
+        const closeCallback = jest.fn();
         const rendered = mount(
             <ResponsibilityCommentModalComponent
                 addResponsibilityComment={submitCallback}
-                setCurrentTouchstoneResponsibility={cancelCallback}
+                setCurrentTouchstoneResponsibility={closeCallback}
                 responsibility={responsibility}
                 currentTouchstoneVersion={touchstone.id}
             />
@@ -43,20 +43,28 @@ describe("ResponsibilityCommentModal", () => {
         rendered.find(".btn-primary").simulate("click", mockEvent());
         expect(submitCallback.mock.calls.length).toEqual(1);
         expect(submitCallback.mock.calls[0]).toEqual([touchstone.id, responsibility, "Ut enim"]);
-        expect(cancelCallback.mock.calls.length).toEqual(0);
+        expect(closeCallback.mock.calls.length).toEqual(1);
+        expect(closeCallback.mock.calls[0]).toEqual([null]);
     })
 
     it("cancels comment", () => {
         const touchstone = mockTouchstoneVersion();
         const responsibility = mockAnnotatedResponsibility();
         const submitCallback = jest.fn();
-        const cancelCallback = jest.fn();
-        const rendered = mount(<ResponsibilityCommentModalComponent addResponsibilityComment={submitCallback} setCurrentTouchstoneResponsibility={cancelCallback} responsibility={responsibility} currentTouchstoneVersion={touchstone.id}/>);
+        const closeCallback = jest.fn();
+        const rendered = mount(
+            <ResponsibilityCommentModalComponent
+                addResponsibilityComment={submitCallback}
+                setCurrentTouchstoneResponsibility={closeCallback}
+                responsibility={responsibility}
+                currentTouchstoneVersion={touchstone.id}
+            />
+        );
         rendered.find(".modal-body textarea").at(0).simulate("change", {target: {value: "Ut enim"}});
         rendered.find(".btn-secondary").simulate("click", mockEvent());
         expect(submitCallback.mock.calls.length).toEqual(0);
-        expect(cancelCallback.mock.calls.length).toEqual(1);
-        expect(cancelCallback.mock.calls[0]).toEqual([null]);
+        expect(closeCallback.mock.calls.length).toEqual(1);
+        expect(closeCallback.mock.calls[0]).toEqual([null]);
     })
 
     it("updates modal", async () => {

--- a/app/src/test/admin/components/Touchstones/SingleVersion/ResponsibilityCommentModalTests.tsx
+++ b/app/src/test/admin/components/Touchstones/SingleVersion/ResponsibilityCommentModalTests.tsx
@@ -59,4 +59,25 @@ describe("ResponsibilityCommentModal", () => {
         expect(cancelCallback.mock.calls[0]).toEqual([null]);
     })
 
+    it("updates modal", async () => {
+        const rendered = mount(
+            <ResponsibilityCommentModalComponent
+                addResponsibilityComment={jest.fn()}
+                setCurrentTouchstoneResponsibility={jest.fn()}
+                responsibility={mockAnnotatedResponsibility()}
+                currentTouchstoneVersion={mockTouchstoneVersion().id}
+            />
+        );
+        expect(rendered.find(".modal-body textarea").at(0).props().value).toEqual("Lorem ipsum");
+        expect(rendered.find(".modal-footer span").at(0).text()).toEqual("Last updated by test.user at 2017-07-13 13:55:29 +0100");
+        const responsibility = mockAnnotatedResponsibility(null, {
+            comment: "Ut enim",
+            added_by: "test.user2",
+            added_on: "2018-07-13 13:55:29 +0100"
+        });
+        rendered.setProps({responsibility});
+        expect(rendered.find(".modal-body textarea").at(0).props().value).toEqual("Ut enim");
+        expect(rendered.find(".modal-footer span").at(0).text()).toEqual("Last updated by test.user2 at 2018-07-13 13:55:29 +0100");
+    })
+
 });

--- a/app/src/test/admin/components/Touchstones/SingleVersion/ResponsibilityListItemTests.tsx
+++ b/app/src/test/admin/components/Touchstones/SingleVersion/ResponsibilityListItemTests.tsx
@@ -1,27 +1,41 @@
-import {mockBurdenEstimateSet, mockResponsibility} from "../../../../mocks/mockModels";
+import {mockBurdenEstimateSet, mockModellingGroup, mockResponsibility} from "../../../../mocks/mockModels";
 import {shallow} from "enzyme";
 
 import * as React from "react";
-import {ResponsibilityListItem} from "../../../../../main/admin/components/Touchstones/SingleTouchstoneVersion/ResponsibilityList";
+import {ResponsibilityListItem} from "../../../../../main/admin/components/Touchstones/SingleTouchstoneVersion/ResponsibilityListItem";
+import {AnnotatedResponsibility} from "../../../../../main/admin/models/AnnotatedResponsibility";
 
 describe("ResponsibilityListItem", () => {
 
     it("renders responsibility with no estimate set", () => {
-        const r = mockResponsibility();
-        const rendered = shallow(<ResponsibilityListItem {...r}/>);
+        const r: AnnotatedResponsibility = {
+            modellingGroup: mockModellingGroup().id,
+            comment: {
+                comment: "Lorem ipsum",
+                added_by: "test.user",
+                added_on: "2017-07-13 13:55:29 +0100"
+            },
+            ...mockResponsibility()
+        };
+        const rendered = shallow(<ResponsibilityListItem responsibility={r} selectResponsibility={jest.fn()}/>);
         const cells = rendered.find("td");
-        expect(cells).toHaveLength(4);
+        expect(cells).toHaveLength(5);
         expect(cells.at(0).text()).toEqual(r.scenario.description);
         expect(cells.at(1).text()).toEqual(r.scenario.disease);
         expect(cells.at(2).text()).toEqual(r.status);
         expect(cells.at(3).text()).toEqual("None");
+        expect(cells.at(4).text()).toContain("Lorem ipsum");
     });
 
     it("renders date of last estimate set", () => {
-        const r = mockResponsibility({current_estimate_set:
-                mockBurdenEstimateSet({uploaded_on: "2017-07-13 13:55:29 +0100"})});
-        const rendered = shallow(<ResponsibilityListItem {...r}/>);
-        expect(rendered.find("td").last().text()).toEqual("2017-07-13 13:55:29 +0100");
+        const r: AnnotatedResponsibility = {
+            modellingGroup: mockModellingGroup().id,
+            ...mockResponsibility({
+                current_estimate_set: mockBurdenEstimateSet({uploaded_on: "2017-07-13 13:55:29 +0100"})
+            })
+        };
+        const rendered = shallow(<ResponsibilityListItem responsibility={r} selectResponsibility={jest.fn()}/>);
+        expect(rendered.find("td").at(3).text()).toEqual("2017-07-13 13:55:29 +0100");
     });
 
 });

--- a/app/src/test/admin/components/Touchstones/SingleVersion/ResponsibilityListItemTests.tsx
+++ b/app/src/test/admin/components/Touchstones/SingleVersion/ResponsibilityListItemTests.tsx
@@ -1,25 +1,20 @@
-import {mockBurdenEstimateSet, mockModellingGroup, mockResponsibility} from "../../../../mocks/mockModels";
+import {
+    mockAnnotatedResponsibility,
+    mockBurdenEstimateSet,
+    mockResponsibility
+} from "../../../../mocks/mockModels";
 import {shallow} from "enzyme";
 
 import * as React from "react";
 import {ResponsibilityListItem} from "../../../../../main/admin/components/Touchstones/SingleTouchstoneVersion/ResponsibilityListItem";
-import {AnnotatedResponsibility} from "../../../../../main/admin/models/AnnotatedResponsibility";
 import {createMockAdminStore} from "../../../../mocks/mockStore";
 import {mockEvent} from "../../../../mocks/mocks";
 
 describe("ResponsibilityListItem", () => {
 
     it("renders responsibility with no estimate set", () => {
-        const r: AnnotatedResponsibility = {
-            ...mockResponsibility(),
-            modellingGroup: mockModellingGroup().id,
-            comment: {
-                comment: "Lorem ipsum",
-                added_by: "test.user",
-                added_on: "2017-07-13 13:55:29 +0100"
-            }
-        };
         const store = createMockAdminStore();
+        const r = mockAnnotatedResponsibility();
         const rendered = shallow(<ResponsibilityListItem responsibility={r}/>, {context: {store}}).dive();
         const cells = rendered.find("td");
         expect(cells).toHaveLength(5);
@@ -31,29 +26,17 @@ describe("ResponsibilityListItem", () => {
     });
 
     it("renders date of last estimate set", () => {
-        const r: AnnotatedResponsibility = {
-            modellingGroup: mockModellingGroup().id,
-            ...mockResponsibility({
-                current_estimate_set: mockBurdenEstimateSet({uploaded_on: "2017-07-13 13:55:29 +0100"})
-            })
-        };
+        const r = mockAnnotatedResponsibility(mockResponsibility({
+            current_estimate_set: mockBurdenEstimateSet({uploaded_on: "2017-07-13 13:55:29 +0100"})
+        }));
         const store = createMockAdminStore();
         const rendered = shallow(<ResponsibilityListItem responsibility={r}/>, {context: {store}}).dive();
         expect(rendered.find("td").at(3).text()).toEqual("2017-07-13 13:55:29 +0100");
     });
 
     it("renders comment and tooltip correctly", () => {
-        const r: AnnotatedResponsibility = {
-            ...mockResponsibility(),
-            modellingGroup: mockModellingGroup().id,
-            comment: {
-                comment: "Lorem ipsum",
-                added_by: "test.user",
-                added_on: "2017-07-13 13:55:29 +0100"
-            }
-        };
         const store = createMockAdminStore();
-        const rendered = shallow(<ResponsibilityListItem responsibility={r}/>, {context: {store}}).dive();
+        const rendered = shallow(<ResponsibilityListItem responsibility={mockAnnotatedResponsibility()}/>, {context: {store}}).dive();
         const td = rendered.find("td").at(4);
         expect(td.find("div").at(0).text()).toEqual("Lorem ipsum");
         expect(td.find("div").at(0).prop("title")).toEqual("Lorem ipsum");
@@ -61,15 +44,7 @@ describe("ResponsibilityListItem", () => {
     });
 
     it("fires action when comment edit link clicked", () => {
-        const r: AnnotatedResponsibility = {
-            ...mockResponsibility(),
-            modellingGroup: mockModellingGroup().id,
-            comment: {
-                comment: "Lorem ipsum",
-                added_by: "test.user",
-                added_on: "2017-07-13 13:55:29 +0100"
-            }
-        };
+        const r = mockAnnotatedResponsibility();
         const store = createMockAdminStore();
         const rendered = shallow(<ResponsibilityListItem responsibility={r}/>, {context: {store}}).dive();
         rendered.find("td").at(4).find("a").simulate("click", mockEvent());

--- a/app/src/test/admin/components/Touchstones/SingleVersion/ResponsibilityListItemTests.tsx
+++ b/app/src/test/admin/components/Touchstones/SingleVersion/ResponsibilityListItemTests.tsx
@@ -4,20 +4,23 @@ import {shallow} from "enzyme";
 import * as React from "react";
 import {ResponsibilityListItem} from "../../../../../main/admin/components/Touchstones/SingleTouchstoneVersion/ResponsibilityListItem";
 import {AnnotatedResponsibility} from "../../../../../main/admin/models/AnnotatedResponsibility";
+import {createMockAdminStore} from "../../../../mocks/mockStore";
+import {mockEvent} from "../../../../mocks/mocks";
 
 describe("ResponsibilityListItem", () => {
 
     it("renders responsibility with no estimate set", () => {
         const r: AnnotatedResponsibility = {
+            ...mockResponsibility(),
             modellingGroup: mockModellingGroup().id,
             comment: {
                 comment: "Lorem ipsum",
                 added_by: "test.user",
                 added_on: "2017-07-13 13:55:29 +0100"
-            },
-            ...mockResponsibility()
+            }
         };
-        const rendered = shallow(<ResponsibilityListItem responsibility={r} selectResponsibility={jest.fn()}/>);
+        const store = createMockAdminStore();
+        const rendered = shallow(<ResponsibilityListItem responsibility={r}/>, {context: {store}}).dive();
         const cells = rendered.find("td");
         expect(cells).toHaveLength(5);
         expect(cells.at(0).text()).toEqual(r.scenario.description);
@@ -34,8 +37,43 @@ describe("ResponsibilityListItem", () => {
                 current_estimate_set: mockBurdenEstimateSet({uploaded_on: "2017-07-13 13:55:29 +0100"})
             })
         };
-        const rendered = shallow(<ResponsibilityListItem responsibility={r} selectResponsibility={jest.fn()}/>);
+        const store = createMockAdminStore();
+        const rendered = shallow(<ResponsibilityListItem responsibility={r}/>, {context: {store}}).dive();
         expect(rendered.find("td").at(3).text()).toEqual("2017-07-13 13:55:29 +0100");
+    });
+
+    it("renders comment and tooltip correctly", () => {
+        const r: AnnotatedResponsibility = {
+            ...mockResponsibility(),
+            modellingGroup: mockModellingGroup().id,
+            comment: {
+                comment: "Lorem ipsum",
+                added_by: "test.user",
+                added_on: "2017-07-13 13:55:29 +0100"
+            }
+        };
+        const store = createMockAdminStore();
+        const rendered = shallow(<ResponsibilityListItem responsibility={r}/>, {context: {store}}).dive();
+        const td = rendered.find("td").at(4);
+        expect(td.find("div").at(0).text()).toEqual("Lorem ipsum");
+        expect(td.find("div").at(0).prop("title")).toEqual("Lorem ipsum");
+        expect(td.find("div").at(1).text()).toEqual("Edit");
+    });
+
+    it("fires action when comment edit link clicked", () => {
+        const r: AnnotatedResponsibility = {
+            ...mockResponsibility(),
+            modellingGroup: mockModellingGroup().id,
+            comment: {
+                comment: "Lorem ipsum",
+                added_by: "test.user",
+                added_on: "2017-07-13 13:55:29 +0100"
+            }
+        };
+        const store = createMockAdminStore();
+        const rendered = shallow(<ResponsibilityListItem responsibility={r}/>, {context: {store}}).dive();
+        rendered.find("td").at(4).find("a").simulate("click", mockEvent());
+        expect(store.getActions()).toEqual([{type: "SET_CURRENT_TOUCHSTONE_RESPONSIBILITY", data: r}]);
     });
 
 });

--- a/app/src/test/admin/components/Touchstones/SingleVersion/ResponsibilityListTests.tsx
+++ b/app/src/test/admin/components/Touchstones/SingleVersion/ResponsibilityListTests.tsx
@@ -1,4 +1,4 @@
-import {mockResponsibility} from "../../../../mocks/mockModels";
+import {mockModellingGroup, mockResponsibility} from "../../../../mocks/mockModels";
 import {shallow} from "enzyme";
 
 import * as React from "react";
@@ -7,14 +7,20 @@ import {ResponsibilityList} from "../../../../../main/admin/components/Touchston
 describe("ResponsibilityList", () => {
 
     it("renders headers", () => {
-        const r = [mockResponsibility()];
-        const rendered = shallow(<ResponsibilityList responsibilities={r}/>);
+        const r = [
+            {
+                modellingGroup: mockModellingGroup().id,
+                ...mockResponsibility()
+            }
+        ];
+        const rendered = shallow(<ResponsibilityList responsibilities={r} selectResponsibility={jest.fn()}/>);
         const cells = rendered.find("th");
-        expect(cells).toHaveLength(4);
+        expect(cells).toHaveLength(5);
         expect(cells.at(0).text()).toEqual("Scenario");
         expect(cells.at(1).text()).toEqual("Disease");
         expect(cells.at(2).text()).toEqual("Status");
         expect(cells.at(3).text()).toEqual("Latest estimate set");
+        expect(cells.at(4).text()).toEqual("Comment");
     });
 
 });

--- a/app/src/test/admin/components/Touchstones/SingleVersion/ResponsibilityListTests.tsx
+++ b/app/src/test/admin/components/Touchstones/SingleVersion/ResponsibilityListTests.tsx
@@ -13,7 +13,7 @@ describe("ResponsibilityList", () => {
                 ...mockResponsibility()
             }
         ];
-        const rendered = shallow(<ResponsibilityList responsibilities={r} selectResponsibility={jest.fn()}/>);
+        const rendered = shallow(<ResponsibilityList responsibilities={r}/>);
         const cells = rendered.find("th");
         expect(cells).toHaveLength(5);
         expect(cells.at(0).text()).toEqual("Scenario");

--- a/app/src/test/admin/components/Touchstones/SingleVersion/TouchstoneResponsibilityPageTests.tsx
+++ b/app/src/test/admin/components/Touchstones/SingleVersion/TouchstoneResponsibilityPageTests.tsx
@@ -18,12 +18,21 @@ import {touchstoneResponsibilitiesPageActionCreators} from
 
 describe("ResponsibilitiesPage", () => {
 
-    const mockResponsibilitySets = [mockResponsibilitySetWithExpectations(), mockResponsibilitySetWithExpectations()];
+    const mockResponsibilitySets = [
+        mockResponsibilitySetWithExpectations({modelling_group_id: "g1"}),
+        mockResponsibilitySetWithExpectations({modelling_group_id: "g2"})
+    ];
 
     let store = createMockAdminStore(mockAdminState({
         touchstones: {
             currentResponsibilitySets: mockResponsibilitySets,
-            currentTouchstoneVersion: mockTouchstoneVersion()
+            currentTouchstoneVersion: mockTouchstoneVersion(),
+            currentResponsibilityComments: mockResponsibilitySets.map(rs => ({
+                modelling_group_id: rs.modelling_group_id,
+                responsibilities: rs.responsibilities.map(r => ({
+                    scenario_id: r.scenario.id
+                }))
+            }))
         }
     }));
 

--- a/app/src/test/admin/reducers/adminTouchstoneReducerTests.ts
+++ b/app/src/test/admin/reducers/adminTouchstoneReducerTests.ts
@@ -1,10 +1,12 @@
-
 import {
     adminTouchstoneReducer,
-    adminTouchstonesInitialState, AdminTouchstoneState
+    adminTouchstonesInitialState,
+    AdminTouchstoneState
 } from "../../../main/admin/reducers/adminTouchstoneReducer";
 import {TouchstonesAction, TouchstoneTypes} from "../../../main/shared/actionTypes/TouchstonesTypes";
-import {mockTouchstone} from "../../mocks/mockModels";
+import {mockResponsibilitySetWithExpectations, mockTouchstone} from "../../mocks/mockModels";
+import {AnnotatedResponsibility} from "../../../main/admin/models/AnnotatedResponsibility";
+import {ResponsibilitySetWithComments} from "../../../main/shared/models/Generated";
 
 describe("adminTouchstoneReducer", () => {
     it("sets fetched touchstones", () => {
@@ -55,6 +57,45 @@ describe("adminTouchstoneReducer", () => {
         const expected: AdminTouchstoneState = {
             ...adminTouchstonesInitialState,
             touchstones: [touchstone]
+        };
+        expect(adminTouchstoneReducer(undefined, action)).toEqual(expected);
+    });
+
+    it("sets current responsibility", () => {
+        const testResponsibilitySet = mockResponsibilitySetWithExpectations();
+        const data: AnnotatedResponsibility = {
+            ...testResponsibilitySet.responsibilities[0],
+            modellingGroup: testResponsibilitySet.modelling_group_id,
+        };
+        const action: TouchstonesAction = {
+            type: TouchstoneTypes.SET_CURRENT_TOUCHSTONE_RESPONSIBILITY,
+            data
+        };
+        const expected: AdminTouchstoneState = {
+            ...adminTouchstonesInitialState,
+            currentResponsibility: data
+        };
+        expect(adminTouchstoneReducer(undefined, action)).toEqual(expected);
+    });
+
+    it("sets annotated responsibility set", () => {
+        const testResponsibilitySet = mockResponsibilitySetWithExpectations();
+        const data: ResponsibilitySetWithComments[] = [{
+            modelling_group_id: testResponsibilitySet.modelling_group_id,
+            touchstone_version: testResponsibilitySet.touchstone_version,
+            responsibilities: testResponsibilitySet.responsibilities.map(r => ({
+                scenario_id: r.scenario.id,
+                comment: null,
+                ...r
+            }))
+        }];
+        const action: TouchstonesAction = {
+            type: TouchstoneTypes.RESPONSIBILITY_COMMENTS_FOR_TOUCHSTONE_VERSION_FETCHED,
+            data
+        };
+        const expected: AdminTouchstoneState = {
+            ...adminTouchstonesInitialState,
+            currentResponsibilityComments: data
         };
         expect(adminTouchstoneReducer(undefined, action)).toEqual(expected);
     });

--- a/app/src/test/admin/reducers/adminTouchstoneReducerTests.ts
+++ b/app/src/test/admin/reducers/adminTouchstoneReducerTests.ts
@@ -4,8 +4,11 @@ import {
     AdminTouchstoneState
 } from "../../../main/admin/reducers/adminTouchstoneReducer";
 import {TouchstonesAction, TouchstoneTypes} from "../../../main/shared/actionTypes/TouchstonesTypes";
-import {mockResponsibilitySetWithExpectations, mockTouchstone} from "../../mocks/mockModels";
-import {AnnotatedResponsibility} from "../../../main/admin/models/AnnotatedResponsibility";
+import {
+    mockAnnotatedResponsibility,
+    mockResponsibilitySetWithExpectations,
+    mockTouchstone
+} from "../../mocks/mockModels";
 import {ResponsibilitySetWithComments} from "../../../main/shared/models/Generated";
 
 describe("adminTouchstoneReducer", () => {
@@ -62,11 +65,7 @@ describe("adminTouchstoneReducer", () => {
     });
 
     it("sets current responsibility", () => {
-        const testResponsibilitySet = mockResponsibilitySetWithExpectations();
-        const data: AnnotatedResponsibility = {
-            ...testResponsibilitySet.responsibilities[0],
-            modellingGroup: testResponsibilitySet.modelling_group_id,
-        };
+        const data = mockAnnotatedResponsibility()
         const action: TouchstonesAction = {
             type: TouchstoneTypes.SET_CURRENT_TOUCHSTONE_RESPONSIBILITY,
             data

--- a/app/src/test/contrib/components/Responsibilities/Overview/List/ResponsibilityListTests.tsx
+++ b/app/src/test/contrib/components/Responsibilities/Overview/List/ResponsibilityListTests.tsx
@@ -40,8 +40,8 @@ describe('Responsibility Overview List Component tests', () => {
 
     it("renders one ResponsibilityComponent per responsibility", () => {
         const props = makeProps([
-            mockResponsibility({}, mockScenario({ id: "scenario-1", disease: "d1" })),
-            mockResponsibility({}, mockScenario({ id: "scenario-2", disease: "d2" }))
+            mockResponsibility({}, mockScenario({ id: "scenario-1", disease: "d1", description: "A" })),
+            mockResponsibility({}, mockScenario({ id: "scenario-2", disease: "d2", description: "B" }))
         ]);
         const rendered = shallow(<ResponsibilityList {...props} />);
         const children = rendered.find(ResponsibilityScenario);

--- a/app/src/test/mocks/mockModels.ts
+++ b/app/src/test/mocks/mockModels.ts
@@ -2,13 +2,12 @@ import * as models from "../../main/shared/models/Generated";
 import {
     ExpectationMapping,
     ModellingGroupCreation,
+    ResponsibilityComment,
     TouchstoneVersion
 } from "../../main/shared/models/Generated";
 import {ExtendedResponsibility, ExtendedResponsibilitySet} from "../../main/contrib/models/ResponsibilitySet";
 import {PageBreadcrumb} from "../../main/shared/components/PageWithHeader/PageProperties";
-import {OutcomeExpectations} from "../../main/shared/models/Generated";
-import {NumberRange} from "../../main/shared/models/Generated";
-import {CohortRestriction} from "../../main/shared/models/Generated";
+import {AnnotatedResponsibility} from "../../main/admin/models/AnnotatedResponsibility";
 
 let counter = 0;
 
@@ -320,4 +319,24 @@ export function mockPageBreadcrumb() {
 
 export function mockBreadcrumbs() {
     return [{url: '/', name: 'A'}, {url: '/b/', name: 'B'}];
+}
+
+export function mockAnnotatedResponsibility(
+    responsibility?: models.Responsibility,
+    comment?: ResponsibilityComment
+)
+    : AnnotatedResponsibility {
+    const responsibilitySet = mockResponsibilitySetWithExpectations(
+        null,
+        [responsibility || mockResponsibility()]
+    );
+    return {
+        ...responsibilitySet.responsibilities[0],
+        modellingGroup: responsibilitySet.modelling_group_id,
+        comment: comment || {
+            comment: "Lorem ipsum",
+            added_by: "test.user",
+            added_on: "2017-07-13 13:55:29 +0100"
+        }
+    };
 }

--- a/app/src/test/shared/services/TouchstonesServiceTests.ts
+++ b/app/src/test/shared/services/TouchstonesServiceTests.ts
@@ -38,4 +38,30 @@ describe('Touchstones service tests', () => {
         expect(getStub.mock.calls[0]).toEqual(['/touchstones/touchstone-1/scenarios/']);
         expect(setOptionsSpy.mock.calls[0]).toEqual([{cacheKey: 'touchstones'}]);
     });
+
+    it('fetches annotated responsibility sets', () => {
+        const touchstoneService = new TouchstonesService(store.dispatch, store.getState);
+
+        const setOptionsSpy = sandbox.setSpy(touchstoneService, "setOptions");
+        const getStub = sandbox.setStubFunc(touchstoneService, "get", () => {
+            return Promise.resolve();
+        });
+
+        touchstoneService.getResponsibilityCommentsForTouchstoneVersion('touchstone-1');
+
+        expect(getStub.mock.calls[0][0]).toEqual('/touchstones/touchstone-1/responsibilities/comments/');
+        expect(setOptionsSpy.mock.calls[0][0]).toEqual({cacheKey: 'responsibilityComments'});
+    });
+
+    it('annotates a responsibility', () => {
+        const touchstoneService = new TouchstonesService(store.dispatch, store.getState);
+
+        const getStub = sandbox.setStubFunc(touchstoneService, "post", () => {
+            return Promise.resolve();
+        });
+
+        touchstoneService.addResponsibilityComment("touchstone-1", "group-1", "scenario-1", "comment 1");
+
+        expect(getStub.mock.calls[0][0]).toEqual('/touchstones/touchstone-1/responsibilities/comments/?group_id=group-1&scenario_id=scenario-1&comment=comment%201');
+    });
 });

--- a/app/src/test/shared/services/TouchstonesServiceTests.ts
+++ b/app/src/test/shared/services/TouchstonesServiceTests.ts
@@ -49,6 +49,7 @@ describe('Touchstones service tests', () => {
 
         touchstoneService.getResponsibilityCommentsForTouchstoneVersion('touchstone-1');
 
+        expect(getStub.mock.calls.length).toEqual(1);
         expect(getStub.mock.calls[0][0]).toEqual('/touchstones/touchstone-1/responsibilities/comments/');
         expect(setOptionsSpy.mock.calls[0][0]).toEqual({cacheKey: 'responsibilityComments'});
     });
@@ -62,6 +63,8 @@ describe('Touchstones service tests', () => {
 
         touchstoneService.addResponsibilityComment("touchstone-1", "group-1", "scenario-1", "comment 1");
 
-        expect(getStub.mock.calls[0][0]).toEqual('/touchstones/touchstone-1/responsibilities/comments/?group_id=group-1&scenario_id=scenario-1&comment=comment%201');
+        expect(getStub.mock.calls.length).toEqual(1);
+        expect(getStub.mock.calls[0][0]).toEqual('/touchstones/touchstone-1/responsibilities/group-1/scenario-1/comments/');
+        expect(getStub.mock.calls[0][1]).toEqual('{"comment":"comment 1"}');
     });
 });

--- a/app/src/webmodels/generate/src/main/kotlin/org/vaccineimpact/api/GenerateTypeDefinitions.kt
+++ b/app/src/webmodels/generate/src/main/kotlin/org/vaccineimpact/api/GenerateTypeDefinitions.kt
@@ -7,6 +7,7 @@ import org.vaccineimpact.api.models.*
 import org.vaccineimpact.api.models.expectations.CohortRestriction
 import org.vaccineimpact.api.models.expectations.TouchstoneModelExpectations
 import org.vaccineimpact.api.models.permissions.AssociateRole
+import org.vaccineimpact.api.models.responsibilities.ResponsibilityCommentPayload
 import org.vaccineimpact.api.models.responsibilities.ResponsibilitySetWithComments
 import org.vaccineimpact.api.models.responsibilities.ResponsibilitySetWithExpectations
 import java.io.File
@@ -45,6 +46,7 @@ fun main(args: Array<String>) {
                         ModelRunParameterSet::class,
                         ResearchModel::class,
                         ResearchModelDetails::class,
+                        ResponsibilityCommentPayload::class,
                         ResponsibilitySetWithComments::class,
                         ResponsibilitySetWithExpectations::class,
                         Result::class,

--- a/app/src/webmodels/generate/src/main/kotlin/org/vaccineimpact/api/GenerateTypeDefinitions.kt
+++ b/app/src/webmodels/generate/src/main/kotlin/org/vaccineimpact/api/GenerateTypeDefinitions.kt
@@ -7,6 +7,7 @@ import org.vaccineimpact.api.models.*
 import org.vaccineimpact.api.models.expectations.CohortRestriction
 import org.vaccineimpact.api.models.expectations.TouchstoneModelExpectations
 import org.vaccineimpact.api.models.permissions.AssociateRole
+import org.vaccineimpact.api.models.responsibilities.ResponsibilitySetWithComments
 import org.vaccineimpact.api.models.responsibilities.ResponsibilitySetWithExpectations
 import java.io.File
 import java.sql.Timestamp
@@ -44,6 +45,7 @@ fun main(args: Array<String>) {
                         ModelRunParameterSet::class,
                         ResearchModel::class,
                         ResearchModelDetails::class,
+                        ResponsibilitySetWithComments::class,
                         ResponsibilitySetWithExpectations::class,
                         Result::class,
                         Scenario::class,

--- a/config/api_version
+++ b/config/api_version
@@ -1,1 +1,1 @@
-master
+VIMC-4734

--- a/config/api_version
+++ b/config/api_version
@@ -1,1 +1,1 @@
-VIMC-4734
+master

--- a/config/db_version
+++ b/config/db_version
@@ -1,1 +1,1 @@
-master
+VIMC-4734

--- a/config/db_version
+++ b/config/db_version
@@ -1,1 +1,1 @@
-VIMC-4734
+master


### PR DESCRIPTION
Summary:
* Fix build: has been failing since https://github.com/vimc/orderly/blame/master/inst/create_orderly_demo.sh#L8
* Fix test: [sorting](https://github.com/vimc/montagu-webapps/blob/master/app/src/main/contrib/components/Responsibilities/Overview/List/ResponsibilityList.tsx#L34) of scenarios without descriptions non-deterministic
* Add modal to allow comments to be created/reviewed
* Requires vimc/montagu-db#159 and vimc/montagu-api#458

To test:
* Spin up the admin app, visit http://localhost:5000/admin/touchstones/op-2018/op-2018-1/responsibilities/ and add some comments

To-do:
- [x] Further tests for modal
- [x] Integration test
- [x] Update config/submodules to point at `master`