### PR TITLE
VIMC-4767 Add comments to responsibility sets

### DIFF
--- a/app/src/integrationTests/AdminIntegrationTests.tsx
+++ b/app/src/integrationTests/AdminIntegrationTests.tsx
@@ -384,10 +384,18 @@ class AdminIntegrationTests extends IntegrationTestSuite {
             const result = await touchstoneService
                 .addResponsibilityComment(touchstoneVersionId, "g1", scenarioId, "comment 1");
             expect(result).toEqual("OK")
-        })
+        });
+
+        it("can annotate responsibility set", async () => {
+            await addResponsibilities(this.db);
+            const touchstoneService = new TouchstonesService(this.store.dispatch, this.store.getState);
+            const result = await touchstoneService
+                .addResponsibilitySetComment(touchstoneVersionId, "g1", "comment 1");
+            expect(result).toEqual("OK")
+        });
 
         it("can retrieve annotated responsibilities", async () => {
-            await addAnnotatedResponsibilities(this.db);
+            await addResponsibilityComments(this.db);
             const touchstoneService = new TouchstonesService(this.store.dispatch, this.store.getState);
             const result = await touchstoneService
                 .getResponsibilityCommentsForTouchstoneVersion(touchstoneVersionId);
@@ -407,6 +415,32 @@ class AdminIntegrationTests extends IntegrationTestSuite {
                             },
                         ],
                         "touchstone_version": "test-1",
+                    },
+                ]
+            );
+        });
+
+        it("can retrieve annotated responsibility set", async () => {
+            await addResponsibilitySetComments(this.db);
+            const touchstoneService = new TouchstonesService(this.store.dispatch, this.store.getState);
+            const result = await touchstoneService
+                .getResponsibilityCommentsForTouchstoneVersion(touchstoneVersionId);
+            expect(result).toEqual(
+                [
+                    {
+                        "modelling_group_id": "g1",
+                        "responsibilities": [
+                            {
+                                "comment": null,
+                                "scenario_id": "yf-1",
+                            },
+                        ],
+                        "touchstone_version": "test-1",
+                        "comment": {
+                            "added_by": "bob",
+                            "added_on": "2021-06-17T08:58:32.233Z",
+                            "comment": "comment B",
+                        },
                     },
                 ]
             );
@@ -507,7 +541,7 @@ function addResponsibilities(db: Client) {
     `))
 }
 
-function addAnnotatedResponsibilities(db: Client) {
+function addResponsibilityComments(db: Client) {
     return addResponsibilities(db)
         .then(() => db.query(`
             DO $$
@@ -518,6 +552,21 @@ function addAnnotatedResponsibilities(db: Client) {
                 INSERT INTO responsibility_comment (responsibility, comment, added_by, added_on)
                 VALUES (responsibility_id, 'comment 1', 'bob', '2021-06-16T08:58:32.233Z'),
                        (responsibility_id, 'comment 2', 'bob', '2021-06-17T08:58:32.233Z');
+            END $$;
+    `))
+}
+
+function addResponsibilitySetComments(db: Client) {
+    return addResponsibilities(db)
+        .then(() => db.query(`
+            DO $$
+                DECLARE responsibility_set_id integer;
+            BEGIN
+                SELECT id INTO responsibility_set_id FROM responsibility_set LIMIT 1;
+
+                INSERT INTO responsibility_set_comment (responsibility_set, comment, added_by, added_on)
+                VALUES (responsibility_set_id, 'comment A', 'bob', '2021-06-16T08:58:32.233Z'),
+                       (responsibility_set_id, 'comment B', 'bob', '2021-06-17T08:58:32.233Z');
             END $$;
     `))
 }

--- a/app/src/main/admin/actions/adminTouchstoneActionCreators.ts
+++ b/app/src/main/admin/actions/adminTouchstoneActionCreators.ts
@@ -15,7 +15,7 @@ import {
     TouchstoneTypes
 } from "../../shared/actionTypes/TouchstonesTypes";
 import {TouchstoneCreation} from "../components/Touchstones/Create/CreateTouchstoneForm";
-import {AnnotatedResponsibility} from "../models/AnnotatedResponsibility";
+import {AnnotatedResponsibility, AnnotatedResponsibilitySet} from "../models/AnnotatedResponsibility";
 
 export const adminTouchstoneActionCreators = {
     getAllTouchstones() {
@@ -46,6 +46,13 @@ export const adminTouchstoneActionCreators = {
         };
     },
 
+    setCurrentTouchstoneResponsibilitySet(responsibilitySet: AnnotatedResponsibilitySet) {
+        return {
+            type: TouchstoneTypes.SET_CURRENT_TOUCHSTONE_RESPONSIBILITY_SET,
+            data: responsibilitySet
+        };
+    },
+
     getResponsibilityCommentsForTouchstoneVersion(touchstoneVersion: string) {
         return async (dispatch: Dispatch<AdminAppState>, getState: () => AdminAppState) => {
                 const responsibilityCommentSets: ResponsibilitySetWithComments[] = await (new TouchstonesService(dispatch, getState))
@@ -63,7 +70,18 @@ export const adminTouchstoneActionCreators = {
             const result = await service.addResponsibilityComment(touchstoneVersion, modellingGroupId, scenarioId, comment);
             if (result) {
                 service.clearCacheForTouchstoneResponsibilityComments(touchstoneVersion);
-                dispatch(this.getResponsibilityCommentsForTouchstoneVersion(touchstoneVersion));
+                await dispatch(this.getResponsibilityCommentsForTouchstoneVersion(touchstoneVersion));
+            }
+        }
+    },
+
+    addResponsibilitySetComment(touchstoneVersion: string, modellingGroupId: string, comment: string) {
+        return async (dispatch: Dispatch<AdminAppState>, getState: () => AdminAppState) => {
+            const service = new TouchstonesService(dispatch, getState);
+            const result = await service.addResponsibilitySetComment(touchstoneVersion, modellingGroupId, comment);
+            if (result) {
+                service.clearCacheForTouchstoneResponsibilityComments(touchstoneVersion);
+                await dispatch(this.getResponsibilityCommentsForTouchstoneVersion(touchstoneVersion));
             }
         }
     },

--- a/app/src/main/admin/components/Touchstones/SingleTouchstoneVersion/CommentModal.tsx
+++ b/app/src/main/admin/components/Touchstones/SingleTouchstoneVersion/CommentModal.tsx
@@ -1,0 +1,59 @@
+import * as React from "react";
+import {Button, Input, Modal, ModalBody, ModalFooter, ModalHeader} from "reactstrap";
+import {ResponsibilityComment} from "../../../../shared/models/Generated";
+
+export interface CommentModalProps {
+    header: string;
+    comment?: ResponsibilityComment;
+    handleCancel: () => void;
+    handleSubmit: (commentText: string) => void;
+}
+
+export interface CommentModalState {
+    commentText: string
+}
+
+export class CommentModal extends React.Component<CommentModalProps, CommentModalState> {
+    constructor(props: CommentModalProps) {
+        super(props);
+        this.state = {
+            commentText: this.props.comment ? this.props.comment.comment : ""
+        };
+    }
+    handleChange(event: React.ChangeEvent<HTMLInputElement>) {
+        this.setState({
+            commentText: event.target.value
+        });
+    }
+    moveCaretToEnd(e: React.FocusEvent<HTMLInputElement>) {
+        const value = e.target.value;
+        e.target.value = "";
+        e.target.value = value;
+    }
+    componentWillReceiveProps(nextProps: Readonly<CommentModalProps>) {
+        this.setState({
+            commentText: nextProps.comment ? nextProps.comment.comment : ""
+        });
+    }
+    render() {
+        return (
+            <div>
+                <Modal isOpen={true} fade={false} centered={true} autoFocus={false} size="lg">
+                    <ModalHeader>
+                        {this.props.header}
+                    </ModalHeader>
+                    <ModalBody>
+                        <Input type="textarea" rows={10} value={this.state.commentText} onChange={this.handleChange.bind(this)} autoFocus onFocus={this.moveCaretToEnd}/>
+                    </ModalBody>
+                    <ModalFooter>
+                        {this.props.comment &&
+                        <span className="text-muted mr-auto">Last updated by {this.props.comment.added_by} at {this.props.comment.added_on}</span>
+                        }
+                        <Button color="secondary" onClick={this.props.handleCancel.bind(this)}>Close</Button>{' '}
+                        <Button color="primary" onClick={this.props.handleSubmit.bind(this, this.state.commentText)}>Save changes</Button>
+                    </ModalFooter>
+                </Modal>
+9            </div>
+        );
+    }
+}

--- a/app/src/main/admin/components/Touchstones/SingleTouchstoneVersion/ResponsibilitiesPage.tsx
+++ b/app/src/main/admin/components/Touchstones/SingleTouchstoneVersion/ResponsibilitiesPage.tsx
@@ -29,36 +29,13 @@ export class ResponsibilitiesPageComponent extends React.Component<Responsibilit
     render(): JSX.Element {
         return <PageArticle title={`Responsibility sets in ${this.props.currentTouchstoneVersionId}`}>
             {this.props.responsibilitySets.map(s =>
-                <ResponsibilitySet
-                    key={s.modelling_group_id}
-                    responsibilitySet={toAnnotatedResponsibilitySet(s, this.props.responsibilityComments)}
-                />
+                <ResponsibilitySet key={s.modelling_group_id} responsibilitySet={s}/>
             )}
             <ResponsibilityCommentModal/>
             <ResponsibilitySetCommentModal/>
         </PageArticle>;
     }
 
-}
-
-function toAnnotatedResponsibilitySet(
-    responsibilitySet: ResponsibilitySetWithExpectations,
-    responsibilityComments: ResponsibilitySetWithComments[]
-): AnnotatedResponsibilitySet {
-    const responsibilitySetWithComments = responsibilityComments
-        .find(e => e.modelling_group_id === responsibilitySet.modelling_group_id)
-    return {
-        comment: responsibilitySetWithComments && responsibilitySetWithComments.comment,
-        ...responsibilitySet,
-        responsibilities: responsibilitySet.responsibilities.map(r => (
-            {
-                modellingGroup: responsibilitySet.modelling_group_id,
-                comment: responsibilitySetWithComments && responsibilitySetWithComments.responsibilities
-                    .find(e => e.scenario_id === r.scenario.id).comment,
-                ...r
-            }
-        ))
-    };
 }
 
 const mapStateToProps = (state: AdminAppState): Partial<ResponsibilitiesPageProps> => {

--- a/app/src/main/admin/components/Touchstones/SingleTouchstoneVersion/ResponsibilityCommentModal.tsx
+++ b/app/src/main/admin/components/Touchstones/SingleTouchstoneVersion/ResponsibilityCommentModal.tsx
@@ -1,11 +1,11 @@
 import * as React from "react";
-import {Button, Input, Modal, ModalBody, ModalFooter, ModalHeader} from "reactstrap";
 import {AdminAppState} from "../../../reducers/adminAppReducers";
 import {compose} from "recompose";
 import {connect} from "react-redux";
 import {AnnotatedResponsibility} from "../../../models/AnnotatedResponsibility";
 import {Dispatch} from "redux";
 import {adminTouchstoneActionCreators} from "../../../actions/adminTouchstoneActionCreators";
+import {CommentModal} from "./CommentModal";
 
 export interface ResponsibilityCommentModalProps {
     responsibility: AnnotatedResponsibility;
@@ -14,53 +14,30 @@ export interface ResponsibilityCommentModalProps {
     setCurrentTouchstoneResponsibility: (responsibility: AnnotatedResponsibility) => void;
 }
 
-export interface ResponsibilityCommentModalState {
-    commentText: string
-}
-
-export class ResponsibilityCommentModalComponent extends React.Component<ResponsibilityCommentModalProps, ResponsibilityCommentModalState> {
+export class ResponsibilityCommentModalComponent extends React.Component<ResponsibilityCommentModalProps> {
     constructor(props: ResponsibilityCommentModalProps) {
         super(props);
-        this.state = {
-            commentText: this.props.responsibility && this.props.responsibility.comment ? this.props.responsibility.comment.comment : ""
-        };
     }
-    handleChange(event: React.ChangeEvent<HTMLInputElement>) {
-        this.setState({
-            commentText: event.target.value
-        });
-    }
+
     handleCancel() {
         this.props.setCurrentTouchstoneResponsibility(null);
     }
-    handleSave() {
-        this.props.addResponsibilityComment(this.props.currentTouchstoneVersion, this.props.responsibility, this.state.commentText);
+
+    handleSubmit(commentText: string) {
+        this.props.addResponsibilityComment(this.props.currentTouchstoneVersion, this.props.responsibility, commentText);
         this.props.setCurrentTouchstoneResponsibility(null);
     }
-    componentWillReceiveProps(nextProps: Readonly<ResponsibilityCommentModalProps>) {
-        this.setState({
-            commentText: nextProps.responsibility && nextProps.responsibility.comment ? nextProps.responsibility.comment.comment : ""
-        });
-    }
+
     render() {
         return (
             <div>
                 {this.props.responsibility &&
-                <Modal isOpen={true} fade={false} centered={true} size="lg">
-                    <ModalHeader>
-                        Comment for {this.props.currentTouchstoneVersion}, {this.props.responsibility.modellingGroup}, {this.props.responsibility.scenario.description}
-                    </ModalHeader>
-                    <ModalBody>
-                        <Input type="textarea" rows={10} value={this.state.commentText} onChange={this.handleChange.bind(this)}/>
-                    </ModalBody>
-                    <ModalFooter>
-                        {this.props.responsibility.comment &&
-                        <span className="text-muted mr-auto">Last updated by {this.props.responsibility.comment.added_by} at {this.props.responsibility.comment.added_on}</span>
-                        }
-                        <Button color="secondary" onClick={this.handleCancel.bind(this)}>Close</Button>{' '}
-                        <Button color="primary" onClick={this.handleSave.bind(this)}>Save changes</Button>
-                    </ModalFooter>
-                </Modal>
+                <CommentModal
+                    header={`Comment for ${this.props.currentTouchstoneVersion}, ${this.props.responsibility.modellingGroup}, ${this.props.responsibility.scenario.description}`}
+                    comment={this.props.responsibility.comment}
+                    handleCancel={this.handleCancel.bind(this)}
+                    handleSubmit={this.handleSubmit.bind(this)}
+                />
                 }
             </div>
         );

--- a/app/src/main/admin/components/Touchstones/SingleTouchstoneVersion/ResponsibilityListItem.tsx
+++ b/app/src/main/admin/components/Touchstones/SingleTouchstoneVersion/ResponsibilityListItem.tsx
@@ -38,8 +38,7 @@ export class ResponsibilityListItemComponent extends React.Component<Responsibil
                     {this.props.responsibility.comment && this.props.responsibility.comment.comment}
                 </div>
                 <div style={{display: "table-cell", textAlign: "right"}}>
-                    <a href="#" className="small" style={{marginLeft: "2em"}}
-                       onClick={this.handleClick.bind(this)}>Edit</a>
+                    <a href="#" className="small ml-2" onClick={this.handleClick.bind(this)}>Edit</a>
                 </div>
             </td>
             }

--- a/app/src/main/admin/components/Touchstones/SingleTouchstoneVersion/ResponsibilitySet.tsx
+++ b/app/src/main/admin/components/Touchstones/SingleTouchstoneVersion/ResponsibilitySet.tsx
@@ -43,14 +43,14 @@ class ResponsibilitySetComponent extends React.Component<ResponsibilitySetProps,
         return <div>
             <h4>{responsibilitySet.modelling_group_id} (<span>{responsibilitySet.status}</span>)</h4>
             {this.props.canReviewResponsibilities &&
-            <div style={{marginBottom: "0.5em", display: "flex"}}>
+            <div className="mb-2" style={{display: "flex"}}>
                 <span className="font-weight-bold">Comment:</span>
-                <span style={{marginLeft: "0.5em", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis"}}
+                <span className="ml-1" style={{whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis"}}
                       title={responsibilitySet.comment && responsibilitySet.comment.comment}>
                             {responsibilitySet.comment && responsibilitySet.comment.comment}
                 </span>
-                <span className="small" style={{marginLeft: "0.5em"}}>
-                    <a href="#" style={{marginLeft: "0.5em"}} onClick={this.handleClick.bind(this)}>Edit</a>
+                <span className="small ml-2">
+                    <a href="#" onClick={this.handleClick.bind(this)}>Edit</a>
                 </span>
             </div>
             }

--- a/app/src/main/admin/components/Touchstones/SingleTouchstoneVersion/ResponsibilitySet.tsx
+++ b/app/src/main/admin/components/Touchstones/SingleTouchstoneVersion/ResponsibilitySet.tsx
@@ -1,0 +1,59 @@
+import * as React from "react";
+import {AdminAppState} from "../../../reducers/adminAppReducers";
+import {Dispatch} from "redux";
+import {connect} from "react-redux";
+import {ResponsibilityList} from "./ResponsibilityList";
+import {AnnotatedResponsibilitySet} from "../../../models/AnnotatedResponsibility";
+import {adminTouchstoneActionCreators} from "../../../actions/adminTouchstoneActionCreators";
+import {compose} from "recompose";
+
+interface ResponsibilitySetProps {
+    responsibilitySet: AnnotatedResponsibilitySet;
+    canReviewResponsibilities: boolean;
+    setCurrentTouchstoneResponsibilitySet: (responsibilitySet: AnnotatedResponsibilitySet) => void;
+}
+
+class ResponsibilitySetComponent extends React.Component<ResponsibilitySetProps> {
+
+    handleClick() {
+        this.props.setCurrentTouchstoneResponsibilitySet(this.props.responsibilitySet);
+    }
+
+    render(): JSX.Element {
+        const responsibilitySet = this.props.responsibilitySet;
+        return <div>
+            <h4>{responsibilitySet.modelling_group_id} (<span>{responsibilitySet.status}</span>)</h4>
+            {this.props.canReviewResponsibilities &&
+            <div style={{marginBottom: "0.5em", display: "flex"}}>
+                <span className="font-weight-bold">Comment:</span>
+                <span style={{marginLeft: "0.5em", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis"}}
+                      title={responsibilitySet.comment && responsibilitySet.comment.comment}>
+                            {responsibilitySet.comment && responsibilitySet.comment.comment}
+                </span>
+                <span className="small" style={{marginLeft: "0.5em"}}>
+                    <a href="#" style={{marginLeft: "0.5em"}} onClick={this.handleClick.bind(this)}>Edit</a>
+                </span>
+            </div>
+            }
+            <ResponsibilityList responsibilities={responsibilitySet.responsibilities}/>
+        </div>
+    }
+
+}
+
+const mapStateToProps = (state: AdminAppState): Partial<ResponsibilitySetProps> => {
+    return {
+        canReviewResponsibilities: state.auth.canReviewResponsibilities
+    }
+};
+
+const mapDispatchToProps = (dispatch: Dispatch<AdminAppState>): Partial<ResponsibilitySetProps> => {
+    return {
+        setCurrentTouchstoneResponsibilitySet: (responsibilitySet: AnnotatedResponsibilitySet) =>
+            dispatch(adminTouchstoneActionCreators.setCurrentTouchstoneResponsibilitySet(responsibilitySet))
+    };
+};
+
+export const ResponsibilitySet = compose<{}, Partial<ResponsibilitySetProps>>(
+    connect(mapStateToProps, mapDispatchToProps)
+)(ResponsibilitySetComponent);

--- a/app/src/main/admin/components/Touchstones/SingleTouchstoneVersion/ResponsibilitySet.tsx
+++ b/app/src/main/admin/components/Touchstones/SingleTouchstoneVersion/ResponsibilitySet.tsx
@@ -6,21 +6,40 @@ import {ResponsibilityList} from "./ResponsibilityList";
 import {AnnotatedResponsibilitySet} from "../../../models/AnnotatedResponsibility";
 import {adminTouchstoneActionCreators} from "../../../actions/adminTouchstoneActionCreators";
 import {compose} from "recompose";
+import {ResponsibilitySetWithComments, ResponsibilitySetWithExpectations} from "../../../../shared/models/Generated";
 
 interface ResponsibilitySetProps {
-    responsibilitySet: AnnotatedResponsibilitySet;
+    responsibilitySet: ResponsibilitySetWithExpectations;
     canReviewResponsibilities: boolean;
+    responsibilityComments: ResponsibilitySetWithComments[];
     setCurrentTouchstoneResponsibilitySet: (responsibilitySet: AnnotatedResponsibilitySet) => void;
 }
 
-class ResponsibilitySetComponent extends React.Component<ResponsibilitySetProps> {
+interface ResponsibilitySetState {
+    annotatedResponsibilitySet: AnnotatedResponsibilitySet;
+}
+
+class ResponsibilitySetComponent extends React.Component<ResponsibilitySetProps, ResponsibilitySetState> {
+
+    constructor(props: ResponsibilitySetProps) {
+        super(props);
+        this.state = {
+            annotatedResponsibilitySet: toAnnotatedResponsibilitySet(props.responsibilitySet, props.responsibilityComments)
+        };
+    }
 
     handleClick() {
-        this.props.setCurrentTouchstoneResponsibilitySet(this.props.responsibilitySet);
+        this.props.setCurrentTouchstoneResponsibilitySet(this.state.annotatedResponsibilitySet);
+    }
+
+    componentWillReceiveProps(nextProps: Readonly<ResponsibilitySetProps>) {
+        this.setState({
+            annotatedResponsibilitySet: toAnnotatedResponsibilitySet(nextProps.responsibilitySet, nextProps.responsibilityComments)
+        });
     }
 
     render(): JSX.Element {
-        const responsibilitySet = this.props.responsibilitySet;
+        const responsibilitySet = this.state.annotatedResponsibilitySet;
         return <div>
             <h4>{responsibilitySet.modelling_group_id} (<span>{responsibilitySet.status}</span>)</h4>
             {this.props.canReviewResponsibilities &&
@@ -41,9 +60,30 @@ class ResponsibilitySetComponent extends React.Component<ResponsibilitySetProps>
 
 }
 
+function toAnnotatedResponsibilitySet(
+    responsibilitySet: ResponsibilitySetWithExpectations,
+    responsibilityComments: ResponsibilitySetWithComments[]
+): AnnotatedResponsibilitySet {
+    const responsibilitySetWithComments = responsibilityComments
+        .find(e => e.modelling_group_id === responsibilitySet.modelling_group_id)
+    return {
+        comment: responsibilitySetWithComments && responsibilitySetWithComments.comment,
+        ...responsibilitySet,
+        responsibilities: responsibilitySet.responsibilities.map(r => (
+            {
+                modellingGroup: responsibilitySet.modelling_group_id,
+                comment: responsibilitySetWithComments && responsibilitySetWithComments.responsibilities
+                    .find(e => e.scenario_id === r.scenario.id).comment,
+                ...r
+            }
+        ))
+    };
+}
+
 const mapStateToProps = (state: AdminAppState): Partial<ResponsibilitySetProps> => {
     return {
-        canReviewResponsibilities: state.auth.canReviewResponsibilities
+        canReviewResponsibilities: state.auth.canReviewResponsibilities,
+        responsibilityComments: state.touchstones.currentResponsibilityComments
     }
 };
 

--- a/app/src/main/admin/components/Touchstones/SingleTouchstoneVersion/ResponsibilitySetCommentModal.tsx
+++ b/app/src/main/admin/components/Touchstones/SingleTouchstoneVersion/ResponsibilitySetCommentModal.tsx
@@ -1,0 +1,69 @@
+import * as React from "react";
+import {AdminAppState} from "../../../reducers/adminAppReducers";
+import {compose} from "recompose";
+import {connect} from "react-redux";
+import {AnnotatedResponsibilitySet} from "../../../models/AnnotatedResponsibility";
+import {Dispatch} from "redux";
+import {adminTouchstoneActionCreators} from "../../../actions/adminTouchstoneActionCreators";
+import {CommentModal} from "./CommentModal";
+
+export interface ResponsibilitySetCommentModalProps {
+    responsibilitySet: AnnotatedResponsibilitySet;
+    currentTouchstoneVersion: string;
+    addResponsibilitySetComment: (currentTouchstoneVersion: string, responsibilitySet: AnnotatedResponsibilitySet, comment: string) => void;
+    setCurrentTouchstoneResponsibilitySet: (responsibilitySet: AnnotatedResponsibilitySet) => void;
+}
+
+export class ResponsibilitySetCommentModalComponent extends React.Component<ResponsibilitySetCommentModalProps> {
+    constructor(props: ResponsibilitySetCommentModalProps) {
+        super(props);
+    }
+
+    handleCancel() {
+        this.props.setCurrentTouchstoneResponsibilitySet(null);
+    }
+
+    handleSubmit(commentText: string) {
+        this.props.addResponsibilitySetComment(this.props.currentTouchstoneVersion, this.props.responsibilitySet, commentText);
+        this.props.setCurrentTouchstoneResponsibilitySet(null);
+    }
+
+    render() {
+        return (
+            <div>
+                {this.props.responsibilitySet &&
+                <CommentModal
+                    header={`Comment for ${this.props.currentTouchstoneVersion}, ${this.props.responsibilitySet.modelling_group_id}`}
+                    comment={this.props.responsibilitySet.comment}
+                    handleCancel={this.handleCancel.bind(this)}
+                    handleSubmit={this.handleSubmit.bind(this)}
+                />
+                }
+            </div>
+        );
+    }
+}
+
+export const mapStateToProps = (state: AdminAppState): Partial<ResponsibilitySetCommentModalProps> => {
+    return {
+        responsibilitySet: state.touchstones.currentResponsibilitySet,
+        currentTouchstoneVersion: state.touchstones.currentTouchstoneVersion && state.touchstones.currentTouchstoneVersion.id
+    }
+};
+
+export const mapDispatchToProps = (dispatch: Dispatch<AdminAppState>): Partial<ResponsibilitySetCommentModalProps> => {
+    return {
+        addResponsibilitySetComment: (currentTouchstoneVersion: string, responsibilitySet, comment: string) =>
+            dispatch(adminTouchstoneActionCreators.addResponsibilitySetComment(
+                currentTouchstoneVersion,
+                responsibilitySet.modelling_group_id,
+                comment
+            )),
+        setCurrentTouchstoneResponsibilitySet: (responsibilitySet: AnnotatedResponsibilitySet) =>
+            dispatch(adminTouchstoneActionCreators.setCurrentTouchstoneResponsibilitySet(responsibilitySet))
+    };
+};
+
+export const ResponsibilitySetCommentModal = compose(
+    connect(mapStateToProps, mapDispatchToProps)
+)(ResponsibilitySetCommentModalComponent) as React.ComponentClass<Partial<ResponsibilitySetCommentModalProps>>;

--- a/app/src/main/admin/models/AnnotatedResponsibility.ts
+++ b/app/src/main/admin/models/AnnotatedResponsibility.ts
@@ -1,6 +1,11 @@
-import {Responsibility, ResponsibilityComment} from "../../shared/models/Generated";
+import {Responsibility, ResponsibilityComment, ResponsibilitySetWithExpectations} from "../../shared/models/Generated";
 
 export interface AnnotatedResponsibility extends Responsibility {
     modellingGroup: string;
+    comment?: ResponsibilityComment;
+}
+
+export interface AnnotatedResponsibilitySet extends ResponsibilitySetWithExpectations {
+    responsibilities: AnnotatedResponsibility[];
     comment?: ResponsibilityComment;
 }

--- a/app/src/main/admin/reducers/adminTouchstoneReducer.ts
+++ b/app/src/main/admin/reducers/adminTouchstoneReducer.ts
@@ -6,7 +6,7 @@ import {
     TouchstoneVersion
 } from "../../shared/models/Generated";
 import {TouchstonesAction, TouchstoneTypes} from "../../shared/actionTypes/TouchstonesTypes";
-import {AnnotatedResponsibility} from "../models/AnnotatedResponsibility";
+import {AnnotatedResponsibility, AnnotatedResponsibilitySet} from "../models/AnnotatedResponsibility";
 
 export interface AdminTouchstoneState {
     touchstones: Touchstone[];
@@ -15,6 +15,7 @@ export interface AdminTouchstoneState {
     currentResponsibilitySets: ResponsibilitySetWithExpectations[];
     currentResponsibilityComments: ResponsibilitySetWithComments[];
     currentResponsibility: AnnotatedResponsibility;
+    currentResponsibilitySet: AnnotatedResponsibilitySet;
     createTouchstoneErrors: ErrorInfo[]
 }
 
@@ -25,6 +26,7 @@ export const adminTouchstonesInitialState: AdminTouchstoneState = {
     currentResponsibilitySets: [],
     currentResponsibilityComments: [],
     currentResponsibility: null,
+    currentResponsibilitySet: null,
     createTouchstoneErrors: []
 };
 export const adminTouchstoneReducer
@@ -42,6 +44,8 @@ export const adminTouchstoneReducer
             return {...state, currentResponsibilityComments: action.data};
         case TouchstoneTypes.SET_CURRENT_TOUCHSTONE_RESPONSIBILITY:
             return {...state, currentResponsibility: action.data};
+        case TouchstoneTypes.SET_CURRENT_TOUCHSTONE_RESPONSIBILITY_SET:
+            return {...state, currentResponsibilitySet: action.data};
         case TouchstoneTypes.NEW_TOUCHSTONE_CREATED:
             return {...state, touchstones: [...state.touchstones, action.data]};
         case TouchstoneTypes.SET_CREATE_TOUCHSTONE_ERROR:

--- a/app/src/main/shared/actionTypes/TouchstonesTypes.ts
+++ b/app/src/main/shared/actionTypes/TouchstonesTypes.ts
@@ -5,13 +5,14 @@ import {
     Touchstone,
     TouchstoneVersion
 } from "../models/Generated";
-import {AnnotatedResponsibility} from "../../admin/models/AnnotatedResponsibility";
+import {AnnotatedResponsibility, AnnotatedResponsibilitySet} from "../../admin/models/AnnotatedResponsibility";
 
 export enum TouchstoneTypes {
     ALL_TOUCHSTONES_FETCHED = "ALL_TOUCHSTONES_FETCHED",
     RESPONSIBILITIES_FOR_TOUCHSTONE_VERSION_FETCHED = "RESPONSIBILITIES_FOR_TOUCHSTONE_VERSION_FETCHED",
     RESPONSIBILITY_COMMENTS_FOR_TOUCHSTONE_VERSION_FETCHED = "RESPONSIBILITY_COMMENTS_FOR_TOUCHSTONE_VERSION_FETCHED",
     SET_CURRENT_TOUCHSTONE_RESPONSIBILITY = "SET_CURRENT_TOUCHSTONE_RESPONSIBILITY",
+    SET_CURRENT_TOUCHSTONE_RESPONSIBILITY_SET = "SET_CURRENT_TOUCHSTONE_RESPONSIBILITY_SET",
     TOUCHSTONES_FETCHED_FOR_GROUP = "TOUCHSTONES_FETCHED_FOR_GROUP",
     SET_CURRENT_TOUCHSTONE_VERSION = "SET_CURRENT_TOUCHSTONE_VERSION",
     NEW_TOUCHSTONE_CREATED = "NEW_TOUCHSTONE_CREATED",
@@ -54,6 +55,11 @@ export interface SetCurrentTouchstoneResponsibility {
     data: AnnotatedResponsibility;
 }
 
+export interface SetCurrentTouchstoneResponsibilitySet {
+    type: TouchstoneTypes.SET_CURRENT_TOUCHSTONE_RESPONSIBILITY_SET;
+    data: AnnotatedResponsibilitySet;
+}
+
 export interface NewTouchstoneCreated {
     type: TouchstoneTypes.NEW_TOUCHSTONE_CREATED;
     data: Touchstone;
@@ -72,5 +78,6 @@ export type TouchstonesAction =
     | ResponsibilitiesForTouchstoneVersionFetched
     | ResponsibilityCommentsForTouchstoneVersionFetched
     | SetCurrentTouchstoneResponsibility
+    | SetCurrentTouchstoneResponsibilitySet
     | NewTouchstoneCreated
     | SetCreateTouchstoneError

--- a/app/src/main/shared/models/Generated.ts
+++ b/app/src/main/shared/models/Generated.ts
@@ -144,6 +144,7 @@ export interface ResponsibilityWithComment {
 }
 
 export interface ResponsibilitySetWithComments {
+    comment: ResponsibilityComment | null;
     modelling_group_id: string;
     responsibilities: ResponsibilityWithComment[];
     touchstone_version: string;

--- a/app/src/main/shared/services/TouchstonesService.ts
+++ b/app/src/main/shared/services/TouchstonesService.ts
@@ -36,6 +36,14 @@ export class TouchstonesService extends AbstractLocalService {
         );
     }
 
+    addResponsibilitySetComment(touchstoneVersion: string, modellingGroupId: string, comment: string) {
+        const responsibilityComment: ResponsibilityCommentPayload = { comment };
+        return this.post(
+            `/touchstones/${touchstoneVersion}/comments/${modellingGroupId}/`,
+            JSON.stringify(responsibilityComment)
+        );
+    }
+
     clearCacheForTouchstoneResponsibilityComments(touchstoneVersion: string) {
         return this.clearCache(TouchstonesCacheKeysEnum.responsibilityComments, `/touchstones/${touchstoneVersion}/responsibilities/comments/`);
     }

--- a/app/src/test/admin/actions/AdminTouchstoneActionTests.ts
+++ b/app/src/test/admin/actions/AdminTouchstoneActionTests.ts
@@ -82,7 +82,7 @@ describe("Admin touchstone action tests", () => {
         }
     );
 
-    it("set currents responsibility", () => {
+    it("sets current responsibility", () => {
         const responsibilitySet = mockResponsibilitySetWithExpectations();
         const responsibility = {
             ...responsibilitySet.responsibilities[0],
@@ -91,6 +91,21 @@ describe("Admin touchstone action tests", () => {
         expect(adminTouchstoneActionCreators.setCurrentTouchstoneResponsibility(responsibility)).toEqual({
             type: TouchstoneTypes.SET_CURRENT_TOUCHSTONE_RESPONSIBILITY,
             data: responsibility
+        });
+    });
+
+    it("sets current responsibility set", () => {
+        const responsibilitySet = mockResponsibilitySetWithExpectations();
+        const annotatedResponsibilitySet = {
+            ...responsibilitySet,
+            responsibilities: responsibilitySet.responsibilities.map( r => ({
+                modellingGroup: responsibilitySet.modelling_group_id,
+                ...r
+            }))
+        };
+        expect(adminTouchstoneActionCreators.setCurrentTouchstoneResponsibilitySet(annotatedResponsibilitySet)).toEqual({
+            type: TouchstoneTypes.SET_CURRENT_TOUCHSTONE_RESPONSIBILITY_SET,
+            data: annotatedResponsibilitySet
         });
     });
 
@@ -110,6 +125,24 @@ describe("Admin touchstone action tests", () => {
                 sandbox.stubService(TouchstonesService.prototype, "getResponsibilityCommentsForTouchstoneVersion");
             },
             callActionCreator: () => adminTouchstoneActionCreators.addResponsibilityComment("t1", "m1", "s1", "c"),
+            expectTheseActions: [
+                {type: TouchstoneTypes.RESPONSIBILITY_COMMENTS_FOR_TOUCHSTONE_VERSION_FETCHED, data: "default_result"}
+            ]
+        });
+        setTimeout(() => {
+            expect(clearCacheStub.mock.calls.length).toBe(1);
+            done();
+        });
+    });
+
+    it("annotates a responsibility set", (done: DoneCallback) => {
+        const clearCacheStub = sandbox.setStubReduxAction(TouchstonesService.prototype, "clearCacheForTouchstoneResponsibilityComments");
+        verifyActionThatCallsService(done, {
+            mockServices: () => {
+                sandbox.stubService(TouchstonesService.prototype, "addResponsibilitySetComment");
+                sandbox.stubService(TouchstonesService.prototype, "getResponsibilityCommentsForTouchstoneVersion");
+            },
+            callActionCreator: () => adminTouchstoneActionCreators.addResponsibilitySetComment("t1", "m1", "c"),
             expectTheseActions: [
                 {type: TouchstoneTypes.RESPONSIBILITY_COMMENTS_FOR_TOUCHSTONE_VERSION_FETCHED, data: "default_result"}
             ]

--- a/app/src/test/admin/components/Touchstones/SingleVersion/ResponsibilitySetCommentModalTests.tsx
+++ b/app/src/test/admin/components/Touchstones/SingleVersion/ResponsibilitySetCommentModalTests.tsx
@@ -1,0 +1,88 @@
+import {mockAnnotatedResponsibilitySet, mockTouchstoneVersion} from "../../../../mocks/mockModels";
+import {createMockAdminStore} from "../../../../mocks/mockStore";
+import {mount} from "enzyme";
+import {
+    ResponsibilitySetCommentModal,
+    ResponsibilitySetCommentModalComponent
+} from "../../../../../main/admin/components/Touchstones/SingleTouchstoneVersion/ResponsibilitySetCommentModal";
+import * as React from "react";
+import {mockEvent} from "../../../../mocks/mocks";
+
+describe("ResponsibilitySetCommentModal", () => {
+
+    it("renders modal", () => {
+        const store = createMockAdminStore({
+            touchstones: {
+                currentTouchstoneVersion: mockTouchstoneVersion(),
+                currentResponsibilitySet: mockAnnotatedResponsibilitySet()
+            }
+        });
+        const rendered = mount(<ResponsibilitySetCommentModal/>, {context: {store}});
+        expect(rendered.find(".modal-title").at(0).text()).toEqual("Comment for touchstone-1, g1");
+        expect(rendered.find(".modal-body textarea").at(0).props().value).toEqual("Duis aute");
+        expect(rendered.find(".modal-footer span").at(0).text()).toEqual("Last updated by test.user at 2018-07-13 13:55:29 +0100");
+    })
+
+    it("saves comment", () => {
+        const touchstone = mockTouchstoneVersion();
+        const responsibilitySet = mockAnnotatedResponsibilitySet();
+        const submitCallback = jest.fn();
+        const closeCallback = jest.fn();
+        const rendered = mount(
+            <ResponsibilitySetCommentModalComponent
+                addResponsibilitySetComment={submitCallback}
+                setCurrentTouchstoneResponsibilitySet={closeCallback}
+                responsibilitySet={responsibilitySet}
+                currentTouchstoneVersion={touchstone.id}
+            />
+        );
+        rendered.find(".modal-body textarea").at(0).simulate("change", {target: {value: "Ut enim"}});
+        rendered.find(".btn-primary").simulate("click", mockEvent());
+        expect(submitCallback.mock.calls.length).toEqual(1);
+        expect(submitCallback.mock.calls[0]).toEqual([touchstone.id, responsibilitySet, "Ut enim"]);
+        expect(closeCallback.mock.calls.length).toEqual(1);
+        expect(closeCallback.mock.calls[0]).toEqual([null]);
+    })
+
+    it("cancels comment", () => {
+        const touchstone = mockTouchstoneVersion();
+        const responsibilitySet = mockAnnotatedResponsibilitySet();
+        const submitCallback = jest.fn();
+        const closeCallback = jest.fn();
+        const rendered = mount(
+            <ResponsibilitySetCommentModalComponent
+                addResponsibilitySetComment={submitCallback}
+                setCurrentTouchstoneResponsibilitySet={closeCallback}
+                responsibilitySet={responsibilitySet}
+                currentTouchstoneVersion={touchstone.id}
+            />
+        );
+        rendered.find(".modal-body textarea").at(0).simulate("change", {target: {value: "Ut enim"}});
+        rendered.find(".btn-secondary").simulate("click", mockEvent());
+        expect(submitCallback.mock.calls.length).toEqual(0);
+        expect(closeCallback.mock.calls.length).toEqual(1);
+        expect(closeCallback.mock.calls[0]).toEqual([null]);
+    })
+
+    it("updates modal", async () => {
+        const rendered = mount(
+            <ResponsibilitySetCommentModalComponent
+                addResponsibilitySetComment={jest.fn()}
+                setCurrentTouchstoneResponsibilitySet={jest.fn()}
+                responsibilitySet={mockAnnotatedResponsibilitySet()}
+                currentTouchstoneVersion={mockTouchstoneVersion().id}
+            />
+        );
+        expect(rendered.find(".modal-body textarea").at(0).props().value).toEqual("Duis aute");
+        expect(rendered.find(".modal-footer span").at(0).text()).toEqual("Last updated by test.user at 2018-07-13 13:55:29 +0100");
+        const responsibilitySet = mockAnnotatedResponsibilitySet({
+            comment: "Ut enim",
+            added_by: "test.user2",
+            added_on: "2019-07-13 13:55:29 +0100"
+        });
+        rendered.setProps({responsibilitySet});
+        expect(rendered.find(".modal-body textarea").at(0).props().value).toEqual("Ut enim");
+        expect(rendered.find(".modal-footer span").at(0).text()).toEqual("Last updated by test.user2 at 2019-07-13 13:55:29 +0100");
+    })
+
+});

--- a/app/src/test/admin/components/Touchstones/SingleVersion/ResponsibilitySetTests.tsx
+++ b/app/src/test/admin/components/Touchstones/SingleVersion/ResponsibilitySetTests.tsx
@@ -1,0 +1,69 @@
+import {mockResponsibilitySetWithExpectations} from "../../../../mocks/mockModels";
+import {shallow} from "enzyme";
+
+import * as React from "react";
+import {createMockAdminStore} from "../../../../mocks/mockStore";
+import {mockEvent} from "../../../../mocks/mocks";
+import {ResponsibilitySet} from "../../../../../main/admin/components/Touchstones/SingleTouchstoneVersion/ResponsibilitySet";
+import {ResponsibilityList} from "../../../../../main/admin/components/Touchstones/SingleTouchstoneVersion/ResponsibilityList";
+
+describe("ResponsibilitySet", () => {
+
+    const responsibilitySet = mockResponsibilitySetWithExpectations({modelling_group_id: "g1"});
+    const annotatedResponsibilitySet = {
+        ...responsibilitySet,
+        responsibilities: responsibilitySet.responsibilities.map(r => ({
+            modellingGroup: responsibilitySet.modelling_group_id,
+            ...r
+        })),
+        comment: {
+            comment: "Lorem ipsum",
+            added_by: "test.user",
+            added_on: "2021-06-17T08:58:32.233Z"
+        }
+    };
+
+    it("renders responsibility list for each responsibility set", () => {
+        const store = createMockAdminStore();
+        const rendered = shallow(<ResponsibilitySet responsibilitySet={annotatedResponsibilitySet}/>,
+            {context: {store}}).dive();
+        expect(rendered.find(ResponsibilityList)).toHaveLength(1);
+    });
+
+    it("renders modelling group name and set status for each set", () => {
+        const store = createMockAdminStore();
+        const rendered = shallow(<ResponsibilitySet responsibilitySet={annotatedResponsibilitySet}/>,
+            {context: {store}}).dive();
+        expect(rendered.find("h4").at(0).text()).toEqual("g1 (incomplete)");
+    });
+
+    it("does not render comment without relevant permission", () => {
+        const store = createMockAdminStore();
+        const rendered = shallow(<ResponsibilitySet responsibilitySet={annotatedResponsibilitySet}/>,
+            {context: {store}}).dive();
+        expect(rendered.find("div div").length).toBe(0);
+    });
+
+    it("renders comment and tooltip with relevant permission", () => {
+        const store = createMockAdminStore({auth: {canReviewResponsibilities: true}});
+        const rendered = shallow(<ResponsibilitySet responsibilitySet={annotatedResponsibilitySet}/>,
+            {context: {store}}).dive();
+        const container = rendered.find("div div").at(0);
+        expect(container.find("span").at(1).text()).toEqual("Lorem ipsum");
+        expect(container.find("span").at(1).prop("title")).toEqual("Lorem ipsum");
+        expect(container.find("span").at(2).text()).toEqual("Edit");
+    });
+
+    it("fires action when comment edit link clicked", () => {
+        const store = createMockAdminStore({auth: {canReviewResponsibilities: true}});
+        const rendered = shallow(<ResponsibilitySet responsibilitySet={annotatedResponsibilitySet}/>,
+            {context: {store}}).dive();
+        const container = rendered.find("div div").at(0);
+        container.find("a").simulate("click", mockEvent());
+        expect(store.getActions()[0]).toEqual({
+            type: "SET_CURRENT_TOUCHSTONE_RESPONSIBILITY_SET",
+            data: annotatedResponsibilitySet
+        });
+    });
+
+});

--- a/app/src/test/admin/components/Touchstones/SingleVersion/TouchstoneResponsibilityPageTests.tsx
+++ b/app/src/test/admin/components/Touchstones/SingleVersion/TouchstoneResponsibilityPageTests.tsx
@@ -1,20 +1,14 @@
-import {
-    mockTouchstoneVersion,
-    mockResponsibilitySetWithExpectations
-} from "../../../../mocks/mockModels";
+import {mockResponsibilitySetWithExpectations} from "../../../../mocks/mockModels";
 import {shallow} from "enzyme";
 
 import * as React from "react";
 import {createMockAdminStore} from "../../../../mocks/mockStore";
 import {mockAdminState} from "../../../../mocks/mockStates";
-import {ResponsibilityList} from
-    "../../../../../main/admin/components/Touchstones/SingleTouchstoneVersion/ResponsibilityList";
-import {ResponsibilitiesPage} from
-    "../../../../../main/admin/components/Touchstones/SingleTouchstoneVersion/ResponsibilitiesPage";
+import {ResponsibilitiesPage} from "../../../../../main/admin/components/Touchstones/SingleTouchstoneVersion/ResponsibilitiesPage";
 import {mockMatch} from "../../../../mocks/mocks";
 import {Sandbox} from "../../../../Sandbox";
-import {touchstoneResponsibilitiesPageActionCreators} from
-    "../../../../../main/admin/actions/pages/TouchstoneResponsibilityPageActionCreators";
+import {touchstoneResponsibilitiesPageActionCreators} from "../../../../../main/admin/actions/pages/TouchstoneResponsibilityPageActionCreators";
+import {ResponsibilitySet} from "../../../../../main/admin/components/Touchstones/SingleTouchstoneVersion/ResponsibilitySet";
 
 describe("ResponsibilitiesPage", () => {
 
@@ -26,11 +20,10 @@ describe("ResponsibilitiesPage", () => {
     let store = createMockAdminStore(mockAdminState({
         touchstones: {
             currentResponsibilitySets: mockResponsibilitySets,
-            currentTouchstoneVersion: mockTouchstoneVersion(),
             currentResponsibilityComments: mockResponsibilitySets.map(rs => ({
                 modelling_group_id: rs.modelling_group_id,
                 responsibilities: rs.responsibilities.map(r => ({
-                    scenario_id: r.scenario.id
+                    scenario_id: r.scenario.id,
                 }))
             }))
         }
@@ -46,24 +39,11 @@ describe("ResponsibilitiesPage", () => {
         sandbox.restore();
     });
 
-    it("renders responsibility list for each responsibility set", () => {
+    it("renders responsibility set for each responsibility set", () => {
 
         const rendered = shallow(<ResponsibilitiesPage location={null} router={null} history={null}
-                                                       match={mockMatch()}/>, {context: {store}})
-            .dive();
-        expect(rendered.find(ResponsibilityList)).toHaveLength(2);
-
-    });
-
-    it("renders modelling group name and set status for each set", () => {
-
-        const rendered = shallow(<ResponsibilitiesPage location={null} router={null} history={null}
-                                                       match={mockMatch()}/>, {context: {store}})
-            .dive();
-
-        expect(rendered.find("h4").at(0).text()).toEqual("g1 (incomplete)");
-
-
+                                                       match={mockMatch()}/>, {context: {store}}).dive().dive();
+        expect(rendered.find(ResponsibilitySet)).toHaveLength(2);
     });
 
 });

--- a/app/src/test/admin/reducers/adminTouchstoneReducerTests.ts
+++ b/app/src/test/admin/reducers/adminTouchstoneReducerTests.ts
@@ -6,6 +6,7 @@ import {
 import {TouchstonesAction, TouchstoneTypes} from "../../../main/shared/actionTypes/TouchstonesTypes";
 import {
     mockAnnotatedResponsibility,
+    mockAnnotatedResponsibilitySet,
     mockResponsibilitySetWithExpectations,
     mockTouchstone
 } from "../../mocks/mockModels";
@@ -37,6 +38,7 @@ describe("adminTouchstoneReducer", () => {
         };
         expect(adminTouchstoneReducer(undefined, action)).toEqual(expected);
     });
+
 
     it("sets create touchstone errors", () => {
         const errors = [{code: "e", message: "error"}];
@@ -77,11 +79,25 @@ describe("adminTouchstoneReducer", () => {
         expect(adminTouchstoneReducer(undefined, action)).toEqual(expected);
     });
 
+    it("sets current responsibility set", () => {
+        const data = mockAnnotatedResponsibilitySet();
+        const action: TouchstonesAction = {
+            type: TouchstoneTypes.SET_CURRENT_TOUCHSTONE_RESPONSIBILITY_SET,
+            data
+        };
+        const expected: AdminTouchstoneState = {
+            ...adminTouchstonesInitialState,
+            currentResponsibilitySet: data
+        };
+        expect(adminTouchstoneReducer(undefined, action)).toEqual(expected);
+    });
+
     it("sets annotated responsibility set", () => {
         const testResponsibilitySet = mockResponsibilitySetWithExpectations();
         const data: ResponsibilitySetWithComments[] = [{
             modelling_group_id: testResponsibilitySet.modelling_group_id,
             touchstone_version: testResponsibilitySet.touchstone_version,
+            comment: null,
             responsibilities: testResponsibilitySet.responsibilities.map(r => ({
                 scenario_id: r.scenario.id,
                 comment: null,

--- a/app/src/test/mocks/mockModels.ts
+++ b/app/src/test/mocks/mockModels.ts
@@ -7,7 +7,7 @@ import {
 } from "../../main/shared/models/Generated";
 import {ExtendedResponsibility, ExtendedResponsibilitySet} from "../../main/contrib/models/ResponsibilitySet";
 import {PageBreadcrumb} from "../../main/shared/components/PageWithHeader/PageProperties";
-import {AnnotatedResponsibility} from "../../main/admin/models/AnnotatedResponsibility";
+import {AnnotatedResponsibility, AnnotatedResponsibilitySet} from "../../main/admin/models/AnnotatedResponsibility";
 
 let counter = 0;
 
@@ -338,5 +338,21 @@ export function mockAnnotatedResponsibility(
             added_by: "test.user",
             added_on: "2017-07-13 13:55:29 +0100"
         }
+    };
+}
+
+export function mockAnnotatedResponsibilitySet(comment?: ResponsibilityComment): AnnotatedResponsibilitySet {
+    const responsibilitySet = mockResponsibilitySetWithExpectations();
+    return {
+        comment: comment || {
+            comment: "Duis aute",
+            added_by: "test.user",
+            added_on: "2018-07-13 13:55:29 +0100"
+        },
+        ...responsibilitySet,
+        responsibilities: responsibilitySet.responsibilities.map(r => ({
+            modellingGroup: responsibilitySet.modelling_group_id,
+            ...r
+        }))
     };
 }

--- a/app/src/test/shared/services/TouchstonesServiceTests.ts
+++ b/app/src/test/shared/services/TouchstonesServiceTests.ts
@@ -67,4 +67,18 @@ describe('Touchstones service tests', () => {
         expect(getStub.mock.calls[0][0]).toEqual('/touchstones/touchstone-1/comments/group-1/scenario-1/');
         expect(getStub.mock.calls[0][1]).toEqual('{"comment":"comment 1"}');
     });
+
+    it('annotates a responsibility set', () => {
+        const touchstoneService = new TouchstonesService(store.dispatch, store.getState);
+
+        const getStub = sandbox.setStubFunc(touchstoneService, "post", () => {
+            return Promise.resolve();
+        });
+
+        touchstoneService.addResponsibilitySetComment("touchstone-1", "group-1", "comment 1");
+
+        expect(getStub.mock.calls.length).toEqual(1);
+        expect(getStub.mock.calls[0][0]).toEqual('/touchstones/touchstone-1/comments/group-1/');
+        expect(getStub.mock.calls[0][1]).toEqual('{"comment":"comment 1"}');
+    });
 });


### PR DESCRIPTION
- Allow comments to be added to responsibility sets, similar to existing functionality for responsibilities
- Main changes to existing code are splitting out new `ResponsibilitySet` and `CommentModal` components - the latter is shared between logic to comment on responsibilities and responsibility sets, and now auto-focuses the textarea
- To test, visit a touchstone version such as http://localhost:5000/admin/touchstones/op-2017/op-2017-2/responsibilities/ - you should be able to add a comment to each responsibility set (there is only one in this case)
- If you remove the test user's permission to annotate responsibility (sets) as [here](https://github.com/vimc/montagu-webapps/pull/464#issue-688714751) then the comment should disappear if you reload the page