### PR TITLE
VIMC-4775 Remove admin role assumption from responsibilities view

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -116,4 +116,4 @@ The `AuthState` properties, and their corresponding permissions are:
 | `canCreateUsers` | `*/users.create` | Users page (CreateUsersSection component)
 | `canCreateModellingGroups` | `*/modelling-groups.write` | Modelling Groups page (CreateModellingGroupSection component)
 | `canManageGroupMembers` | `*/modelling-groups.manage-members` | Modelling Group details page (several components)
-
+| `canReviewResponsibilities` | `*/responsibilities.review` | Touchstone responsibilities page (to view/edit annotations)

--- a/app/src/integrationTests/AdminIntegrationTests.tsx
+++ b/app/src/integrationTests/AdminIntegrationTests.tsx
@@ -395,6 +395,7 @@ class AdminIntegrationTests extends IntegrationTestSuite {
                 [
                     {
                         "modelling_group_id": "g1",
+                        "comment": null,
                         "responsibilities": [
                             {
                                 "comment": {

--- a/app/src/main/admin/actions/pages/TouchstoneResponsibilityPageActionCreators.ts
+++ b/app/src/main/admin/actions/pages/TouchstoneResponsibilityPageActionCreators.ts
@@ -25,7 +25,9 @@ class TouchstoneResponsibilitiesPageActionCreators
             const touchstones = getState().touchstones.touchstones;
             dispatch(touchstonesActionCreators.setCurrentTouchstoneVersion(params.touchstoneVersionId, touchstones));
             dispatch(adminTouchstoneActionCreators.getResponsibilitiesForTouchstoneVersion(params.touchstoneVersionId));
-            dispatch(adminTouchstoneActionCreators.getResponsibilityCommentsForTouchstoneVersion(params.touchstoneVersionId));
+            if (getState().auth.canReviewResponsibilities) {
+                dispatch(adminTouchstoneActionCreators.getResponsibilityCommentsForTouchstoneVersion(params.touchstoneVersionId));
+            }
         }
     }
 

--- a/app/src/main/admin/components/Touchstones/SingleTouchstoneVersion/ResponsibilitiesPage.tsx
+++ b/app/src/main/admin/components/Touchstones/SingleTouchstoneVersion/ResponsibilitiesPage.tsx
@@ -6,10 +6,7 @@ import {Dispatch} from "redux";
 import {connect} from "react-redux";
 import {touchstoneResponsibilitiesPageActionCreators} from "../../../actions/pages/TouchstoneResponsibilityPageActionCreators";
 import {ResponsibilityList} from "./ResponsibilityList";
-import {
-    ResponsibilitySetWithComments,
-    ResponsibilitySetWithExpectations
-} from "../../../../shared/models/Generated";
+import {ResponsibilitySetWithComments, ResponsibilitySetWithExpectations} from "../../../../shared/models/Generated";
 import {compose} from "recompose";
 import {TouchstoneVersionPageLocationProps} from "./TouchstoneVersionPage";
 import {ResponsibilityCommentModal} from "./ResponsibilityCommentModal";
@@ -28,21 +25,21 @@ export class ResponsibilitiesPageComponent extends React.Component<Responsibilit
     }
 
     toAnnotatedResponsibilities(responsibilitySet: ResponsibilitySetWithExpectations): AnnotatedResponsibility[] {
-        return responsibilitySet.responsibilities.map(r => (
-            {
+        return responsibilitySet.responsibilities.map(r => {
+            const responsibilitySetWithComments = this.props.responsibilityComments
+                .find(e => e.modelling_group_id === responsibilitySet.modelling_group_id)
+            return {
                 modellingGroup: responsibilitySet.modelling_group_id,
-                comment: this.props.responsibilityComments
-                    .find(e => e.modelling_group_id === responsibilitySet.modelling_group_id)
-                    .responsibilities
-                    .find(e => e.scenario_id === r.scenario.id).comment,
+                comment: responsibilitySetWithComments &&
+                    responsibilitySetWithComments.responsibilities.find(e => e.scenario_id === r.scenario.id).comment,
                 ...r
             }
-        ));
+        });
     }
 
     render(): JSX.Element {
         return <PageArticle title={`Responsibility sets in ${this.props.currentTouchstoneVersionId}`}>
-            {this.props.responsibilityComments.length && this.props.responsibilitySets.map(s => <div key={s.modelling_group_id}>
+            {this.props.responsibilitySets.map(s => <div key={s.modelling_group_id}>
                 <h4>{s.modelling_group_id} (<span>{s.status}</span>)</h4>
                 <ResponsibilityList responsibilities={this.toAnnotatedResponsibilities(s)}/>
             </div>)}

--- a/app/src/main/admin/components/Touchstones/SingleTouchstoneVersion/ResponsibilityList.tsx
+++ b/app/src/main/admin/components/Touchstones/SingleTouchstoneVersion/ResponsibilityList.tsx
@@ -1,24 +1,41 @@
 import * as React from "react";
 import {ResponsibilityListItem} from "./ResponsibilityListItem";
 import {AnnotatedResponsibility} from "../../../models/AnnotatedResponsibility";
+import {AdminAppState} from "../../../reducers/adminAppReducers";
+import {compose} from "recompose";
+import {connect} from "react-redux";
 
 interface ResponsibilityListProps {
     responsibilities: AnnotatedResponsibility[];
+    canReviewResponsibilities: boolean;
 }
 
-export const ResponsibilityList: React.FunctionComponent<ResponsibilityListProps> = (props: ResponsibilityListProps) => {
-    return <table>
-        <thead>
-        <tr>
-            <th>Scenario</th>
-            <th>Disease</th>
-            <th>Status</th>
-            <th>Latest estimate set</th>
-            <th>Comment</th>
-        </tr>
-        </thead>
-        <tbody>
-        {props.responsibilities.map(r => <ResponsibilityListItem responsibility={r} key={r.scenario.id}/>)}
-        </tbody>
-    </table>;
+export class ResponsibilityListComponent extends React.Component<ResponsibilityListProps> {
+    render() {
+        return <table>
+            <thead>
+            <tr>
+                <th>Scenario</th>
+                <th>Disease</th>
+                <th>Status</th>
+                <th>Latest estimate set</th>
+                {this.props.canReviewResponsibilities &&
+                <th>Comment</th>
+                }
+            </tr>
+            </thead>
+            <tbody>
+            {this.props.responsibilities.map(r => <ResponsibilityListItem responsibility={r} key={r.scenario.id}/>)}
+            </tbody>
+        </table>;
+    }
+}
+
+const mapStateToProps = (state: AdminAppState): Partial<ResponsibilityListProps> => {
+    return {
+        canReviewResponsibilities: state.auth.canReviewResponsibilities,
+    }
 };
+
+export const ResponsibilityList = compose(connect(mapStateToProps))
+(ResponsibilityListComponent) as React.ComponentClass<Partial<ResponsibilityListProps>>;

--- a/app/src/main/admin/components/Touchstones/SingleTouchstoneVersion/ResponsibilityListItem.tsx
+++ b/app/src/main/admin/components/Touchstones/SingleTouchstoneVersion/ResponsibilityListItem.tsx
@@ -8,6 +8,7 @@ import {connect} from "react-redux";
 
 export interface ResponsibilityListItemProps {
     responsibility: AnnotatedResponsibility;
+    canReviewResponsibilities: boolean;
     setCurrentTouchstoneResponsibility: (responsibility: AnnotatedResponsibility) => void;
 }
 
@@ -24,6 +25,7 @@ export class ResponsibilityListItemComponent extends React.Component<Responsibil
             <td>{this.props.responsibility.scenario.disease}</td>
             <td>{this.props.responsibility.status}</td>
             <td>{this.props.responsibility.current_estimate_set ? this.props.responsibility.current_estimate_set.uploaded_on : "None"}</td>
+            {this.props.canReviewResponsibilities &&
             <td>
                 <div style={{
                     display: "table-cell",
@@ -36,12 +38,20 @@ export class ResponsibilityListItemComponent extends React.Component<Responsibil
                     {this.props.responsibility.comment && this.props.responsibility.comment.comment}
                 </div>
                 <div style={{display: "table-cell", textAlign: "right"}}>
-                    <a href="#" className="small" style={{marginLeft: "2em"}} onClick={this.handleClick.bind(this)}>Edit</a>
+                    <a href="#" className="small" style={{marginLeft: "2em"}}
+                       onClick={this.handleClick.bind(this)}>Edit</a>
                 </div>
             </td>
+            }
         </tr>;
     }
 }
+
+const mapStateToProps = (state: AdminAppState): Partial<ResponsibilityListItemProps> => {
+    return {
+        canReviewResponsibilities: state.auth.canReviewResponsibilities,
+    }
+};
 
 export const mapDispatchToProps = (dispatch: Dispatch<AdminAppState>): Partial<ResponsibilityListItemProps> => {
     return {
@@ -51,5 +61,5 @@ export const mapDispatchToProps = (dispatch: Dispatch<AdminAppState>): Partial<R
 };
 
 export const ResponsibilityListItem = compose(
-    connect(state => state, mapDispatchToProps))
+    connect(mapStateToProps, mapDispatchToProps))
 (ResponsibilityListItemComponent) as React.ComponentClass<Partial<ResponsibilityListItemProps>>;

--- a/app/src/main/shared/reducers/authReducer.ts
+++ b/app/src/main/shared/reducers/authReducer.ts
@@ -18,6 +18,7 @@ export interface AuthState {
     canWriteRoles: boolean;
     canCreateUsers: boolean;
     canCreateModellingGroups: boolean;
+    canReviewResponsibilities: boolean;
     canManageGroupMembers: boolean;
 }
 
@@ -36,6 +37,7 @@ export const initialAuthState: AuthState = {
     canWriteRoles: false,
     canCreateUsers: false,
     canCreateModellingGroups: false,
+    canReviewResponsibilities: false,
     canManageGroupMembers: false
 };
 
@@ -67,6 +69,7 @@ export function loadAuthState(options: AuthStateOptions): AuthState {
         canWriteRoles: permissionsInclude(options.permissions,"*/roles.write"),
         canCreateUsers: permissionsInclude(options.permissions,"*/users.create"),
         canCreateModellingGroups: permissionsInclude(options.permissions,"*/modelling-groups.write"),
+        canReviewResponsibilities: permissionsInclude(options.permissions, "*/responsibilities.review"),
         canManageGroupMembers: permissionsInclude(options.permissions,"*/modelling-groups.manage-members")
     }
 }

--- a/app/src/main/shared/services/TouchstonesService.ts
+++ b/app/src/main/shared/services/TouchstonesService.ts
@@ -31,7 +31,7 @@ export class TouchstonesService extends AbstractLocalService {
     addResponsibilityComment(touchstoneVersion: string, modellingGroupId: string, scenarioId: string, comment: string) {
         const responsibilityComment: ResponsibilityCommentPayload = { comment };
         return this.post(
-            `/touchstones/${touchstoneVersion}/responsibilities/${modellingGroupId}/${scenarioId}/comments/`,
+            `/touchstones/${touchstoneVersion}/comments/${modellingGroupId}/${scenarioId}/`,
             JSON.stringify(responsibilityComment)
         );
     }

--- a/app/src/test/admin/actions/pages/TouchstoneResponsibilitiesPageActionTests.ts
+++ b/app/src/test/admin/actions/pages/TouchstoneResponsibilitiesPageActionTests.ts
@@ -16,8 +16,30 @@ describe("Touchstone responsibility page actions tests", () => {
         sandbox.restore();
     });
 
-    it("loads data", (done) => {
+    it("loads data without permission to view comments", (done) => {
         const store = createMockAdminStore({touchstones: {touchstones: [mockTouchstone()]}});
+
+        const setCurrentStub = sandbox.setStubReduxAction(touchstonesActionCreators, "setCurrentTouchstoneVersion");
+        const responsibilitiesStub =
+            sandbox.setStubReduxAction(adminTouchstoneActionCreators, "getResponsibilitiesForTouchstoneVersion");
+        const responsibilitiesCommentsStub =
+            sandbox.setStubReduxAction(adminTouchstoneActionCreators, "getResponsibilityCommentsForTouchstoneVersion");
+
+        store.dispatch(touchstoneResponsibilitiesPageActionCreators
+            .loadData({touchstoneVersionId: "t1", touchstoneId: "whatever"}));
+        setTimeout(() => {
+            expect(setCurrentStub.mock.calls.length).toBe(1);
+            expect(responsibilitiesStub.mock.calls.length).toBe(1);
+            expect(responsibilitiesCommentsStub.mock.calls.length).toBe(0);
+            done();
+        });
+    });
+
+    it("loads data with permission to view comments", (done) => {
+        const store = createMockAdminStore({
+            touchstones: {touchstones: [mockTouchstone()]},
+            auth: {canReviewResponsibilities: true}
+        });
 
         const setCurrentStub = sandbox.setStubReduxAction(touchstonesActionCreators, "setCurrentTouchstoneVersion");
         const responsibilitiesStub =

--- a/app/src/test/admin/components/Touchstones/SingleVersion/ResponsibilityListItemTests.tsx
+++ b/app/src/test/admin/components/Touchstones/SingleVersion/ResponsibilityListItemTests.tsx
@@ -12,8 +12,20 @@ import {mockEvent} from "../../../../mocks/mocks";
 
 describe("ResponsibilityListItem", () => {
 
-    it("renders responsibility with no estimate set", () => {
+    it("renders responsibility with no estimate set without permission to view comments", () => {
         const store = createMockAdminStore();
+        const r = mockAnnotatedResponsibility();
+        const rendered = shallow(<ResponsibilityListItem responsibility={r}/>, {context: {store}}).dive();
+        const cells = rendered.find("td");
+        expect(cells).toHaveLength(4);
+        expect(cells.at(0).text()).toEqual(r.scenario.description);
+        expect(cells.at(1).text()).toEqual(r.scenario.disease);
+        expect(cells.at(2).text()).toEqual(r.status);
+        expect(cells.at(3).text()).toEqual("None");
+    });
+
+    it("renders responsibility with no estimate set with permission to view comments", () => {
+        const store = createMockAdminStore({auth: {canReviewResponsibilities: true}});
         const r = mockAnnotatedResponsibility();
         const rendered = shallow(<ResponsibilityListItem responsibility={r}/>, {context: {store}}).dive();
         const cells = rendered.find("td");
@@ -35,7 +47,7 @@ describe("ResponsibilityListItem", () => {
     });
 
     it("renders comment and tooltip correctly", () => {
-        const store = createMockAdminStore();
+        const store = createMockAdminStore({auth: {canReviewResponsibilities: true}});
         const rendered = shallow(<ResponsibilityListItem responsibility={mockAnnotatedResponsibility()}/>, {context: {store}}).dive();
         const td = rendered.find("td").at(4);
         expect(td.find("div").at(0).text()).toEqual("Lorem ipsum");
@@ -45,7 +57,7 @@ describe("ResponsibilityListItem", () => {
 
     it("fires action when comment edit link clicked", () => {
         const r = mockAnnotatedResponsibility();
-        const store = createMockAdminStore();
+        const store = createMockAdminStore({auth: {canReviewResponsibilities: true}});
         const rendered = shallow(<ResponsibilityListItem responsibility={r}/>, {context: {store}}).dive();
         rendered.find("td").at(4).find("a").simulate("click", mockEvent());
         expect(store.getActions()).toEqual([{type: "SET_CURRENT_TOUCHSTONE_RESPONSIBILITY", data: r}]);

--- a/app/src/test/admin/components/Touchstones/SingleVersion/ResponsibilityListTests.tsx
+++ b/app/src/test/admin/components/Touchstones/SingleVersion/ResponsibilityListTests.tsx
@@ -3,17 +3,36 @@ import {shallow} from "enzyme";
 
 import * as React from "react";
 import {ResponsibilityList} from "../../../../../main/admin/components/Touchstones/SingleTouchstoneVersion/ResponsibilityList";
+import {createMockAdminStore} from "../../../../mocks/mockStore";
 
 describe("ResponsibilityList", () => {
 
-    it("renders headers", () => {
+    it("renders headers without permission to view comments", () => {
         const r = [
             {
                 modellingGroup: mockModellingGroup().id,
                 ...mockResponsibility()
             }
         ];
-        const rendered = shallow(<ResponsibilityList responsibilities={r}/>);
+        const store = createMockAdminStore();
+        const rendered = shallow(<ResponsibilityList responsibilities={r}/>, {context: {store}}).dive();
+        const cells = rendered.find("th");
+        expect(cells).toHaveLength(4);
+        expect(cells.at(0).text()).toEqual("Scenario");
+        expect(cells.at(1).text()).toEqual("Disease");
+        expect(cells.at(2).text()).toEqual("Status");
+        expect(cells.at(3).text()).toEqual("Latest estimate set");
+    });
+
+    it("renders headers with permission to view comments", () => {
+        const r = [
+            {
+                modellingGroup: mockModellingGroup().id,
+                ...mockResponsibility()
+            }
+        ];
+        const store = createMockAdminStore({auth: {canReviewResponsibilities: true}});
+        const rendered = shallow(<ResponsibilityList responsibilities={r}/>, {context: {store}}).dive();
         const cells = rendered.find("th");
         expect(cells).toHaveLength(5);
         expect(cells.at(0).text()).toEqual("Scenario");

--- a/app/src/test/mocks/mockStates.ts
+++ b/app/src/test/mocks/mockStates.ts
@@ -43,6 +43,7 @@ export const mockAuthStateObject: AuthState = {
     canWriteRoles: false,
     canCreateUsers: false,
     canCreateModellingGroups: false,
+    canReviewResponsibilities: false,
     canManageGroupMembers: false
 };
 

--- a/app/src/test/shared/reducers/AuthReducersTests.ts
+++ b/app/src/test/shared/reducers/AuthReducersTests.ts
@@ -20,6 +20,7 @@ const testAuthData: AuthState = {
     canWriteRoles: false,
     canCreateUsers: false,
     canCreateModellingGroups: false,
+    canReviewResponsibilities: false,
     canManageGroupMembers: false
 };
 

--- a/app/src/test/shared/reducers/AuthReducersTests.ts
+++ b/app/src/test/shared/reducers/AuthReducersTests.ts
@@ -99,6 +99,7 @@ describe ('loadAuthState tests', () => {
             result.canWriteRoles,
             result.canCreateUsers,
             result.canCreateModellingGroups,
+            result.canReviewResponsibilities,
             result.canManageGroupMembers
         );
     });
@@ -174,5 +175,9 @@ describe ('loadAuthState tests', () => {
 
     it('sets canManageGroupMembers if modelling groups manage members permission present', () => {
         expect(loadAuthStateWithPermission("*/modelling-groups.manage-members").canManageGroupMembers).toBe(true);
+    });
+
+    it('sets canReviewResponsibilities if responsibilities review permission present', () => {
+        expect(loadAuthStateWithPermission("*/responsibilities.review").canReviewResponsibilities).toBe(true);
     });
 });

--- a/app/src/test/shared/services/TouchstonesServiceTests.ts
+++ b/app/src/test/shared/services/TouchstonesServiceTests.ts
@@ -64,7 +64,7 @@ describe('Touchstones service tests', () => {
         touchstoneService.addResponsibilityComment("touchstone-1", "group-1", "scenario-1", "comment 1");
 
         expect(getStub.mock.calls.length).toEqual(1);
-        expect(getStub.mock.calls[0][0]).toEqual('/touchstones/touchstone-1/responsibilities/group-1/scenario-1/comments/');
+        expect(getStub.mock.calls[0][0]).toEqual('/touchstones/touchstone-1/comments/group-1/scenario-1/');
         expect(getStub.mock.calls[0][1]).toEqual('{"comment":"comment 1"}');
     });
 });


### PR DESCRIPTION
- Ensure that touchstone responsibility page renders correctly
  - If you have `responsibilities.review` permission (i.e. the typical situation of having the `admin` role) then you see the comments column and can add/edit comments
  - If you just don't have that permission (i.e. you have the `user` role) then the page loads regardless but you can't see the column. The endpoint itself is already protected.
- You can test this by running the app, visiting (e.g.) [this page](http://localhost:5000/admin/touchstones/op-2017/op-2017-2/responsibilities/) and checking you can add/edit comments. Then remove `admin` role from `test.user` and revisit the page:
  ```sh
  docker exec -it montagu_db_1 psql -Uvimc montagu -c "delete from user_group_role where role = 17"
  ```
- This PR also updates URL of commenting endpoint to match latest `montagu-api`
- Some further streamlining to how annotated responsibility sets are passed between state/components will follow in VIMC-4767