### PR TITLE
VIMC-4737 Export responsibilities summary for a touchstone

### DIFF
--- a/app/src/main/admin/components/Touchstones/SingleTouchstoneVersion/CommentModal.tsx
+++ b/app/src/main/admin/components/Touchstones/SingleTouchstoneVersion/CommentModal.tsx
@@ -53,7 +53,7 @@ export class CommentModal extends React.Component<CommentModalProps, CommentModa
                         <Button color="primary" onClick={this.props.handleSubmit.bind(this, this.state.commentText)}>Save changes</Button>
                     </ModalFooter>
                 </Modal>
-9            </div>
+            </div>
         );
     }
 }

--- a/app/src/main/admin/components/Touchstones/SingleTouchstoneVersion/ResponsibilitiesPage.tsx
+++ b/app/src/main/admin/components/Touchstones/SingleTouchstoneVersion/ResponsibilitiesPage.tsx
@@ -9,15 +9,16 @@ import {ResponsibilitySetWithComments, ResponsibilitySetWithExpectations} from "
 import {branch, compose, renderComponent} from "recompose";
 import {TouchstoneVersionPageLocationProps} from "./TouchstoneVersionPage";
 import {ResponsibilityCommentModal} from "./ResponsibilityCommentModal";
-import {AnnotatedResponsibilitySet} from "../../../models/AnnotatedResponsibility";
 import {ResponsibilitySetCommentModal} from "./ResponsibilitySetCommentModal";
 import {ResponsibilitySet} from "./ResponsibilitySet";
 import {LoadingElement} from "../../../../shared/partials/LoadingElement/LoadingElement";
+import {FileDownloadButton} from "../../../../shared/components/FileDownloadLink";
 
 export interface ResponsibilitiesPageProps extends PageProperties<TouchstoneVersionPageLocationProps> {
     currentTouchstoneVersionId: string;
     responsibilitySets: ResponsibilitySetWithExpectations[];
     responsibilityComments: ResponsibilitySetWithComments[];
+    canReviewResponsibilities: boolean;
 }
 
 export class ResponsibilitiesPageComponent extends React.Component<ResponsibilitiesPageProps> {
@@ -28,6 +29,12 @@ export class ResponsibilitiesPageComponent extends React.Component<Responsibilit
 
     render(): JSX.Element {
         return <PageArticle title={`Responsibility sets in ${this.props.currentTouchstoneVersionId}`}>
+            {this.props.canReviewResponsibilities &&
+            <FileDownloadButton href={`/touchstones/${this.props.currentTouchstoneVersionId}/responsibilities/csv/`}
+                                className="mb-4">
+                Responsibilities summary
+            </FileDownloadButton>
+            }
             {this.props.responsibilitySets.map(s =>
                 <ResponsibilitySet key={s.modelling_group_id} responsibilitySet={s}/>
             )}
@@ -44,7 +51,8 @@ const mapStateToProps = (state: AdminAppState): Partial<ResponsibilitiesPageProp
             ? state.touchstones.currentTouchstoneVersion.id
             : '',
         responsibilitySets: state.touchstones.currentResponsibilitySets,
-        responsibilityComments: state.touchstones.currentResponsibilityComments
+        responsibilityComments: state.touchstones.currentResponsibilityComments,
+        canReviewResponsibilities: state.auth.canReviewResponsibilities
     }
 };
 

--- a/app/src/main/admin/components/Touchstones/SingleTouchstoneVersion/ResponsibilitySet.tsx
+++ b/app/src/main/admin/components/Touchstones/SingleTouchstoneVersion/ResponsibilitySet.tsx
@@ -43,7 +43,7 @@ class ResponsibilitySetComponent extends React.Component<ResponsibilitySetProps,
         return <div>
             <h4>{responsibilitySet.modelling_group_id} (<span>{responsibilitySet.status}</span>)</h4>
             {this.props.canReviewResponsibilities &&
-            <div className="mb-2" style={{display: "flex"}}>
+            <div className="mb-2" style={{display: "flex", alignItems: "center"}}>
                 <span className="font-weight-bold">Comment:</span>
                 <span className="ml-1" style={{whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis"}}
                       title={responsibilitySet.comment && responsibilitySet.comment.comment}>

--- a/app/src/test/admin/components/Touchstones/SingleVersion/TouchstoneResponsibilityPageTests.tsx
+++ b/app/src/test/admin/components/Touchstones/SingleVersion/TouchstoneResponsibilityPageTests.tsx
@@ -9,6 +9,7 @@ import {mockMatch} from "../../../../mocks/mocks";
 import {Sandbox} from "../../../../Sandbox";
 import {touchstoneResponsibilitiesPageActionCreators} from "../../../../../main/admin/actions/pages/TouchstoneResponsibilityPageActionCreators";
 import {ResponsibilitySet} from "../../../../../main/admin/components/Touchstones/SingleTouchstoneVersion/ResponsibilitySet";
+import {FileDownloadButton} from "../../../../../main/shared/components/FileDownloadLink";
 
 describe("ResponsibilitiesPage", () => {
 
@@ -25,7 +26,13 @@ describe("ResponsibilitiesPage", () => {
                 responsibilities: rs.responsibilities.map(r => ({
                     scenario_id: r.scenario.id,
                 }))
-            }))
+            })),
+            currentTouchstoneVersion: {
+                id: "v1"
+            }
+        },
+        auth: {
+            canReviewResponsibilities: true
         }
     }));
 
@@ -43,6 +50,8 @@ describe("ResponsibilitiesPage", () => {
 
         const rendered = shallow(<ResponsibilitiesPage location={null} router={null} history={null}
                                                        match={mockMatch()}/>, {context: {store}}).dive().dive();
+        expect(rendered.find(FileDownloadButton)).toHaveLength(1);
+        expect(rendered.find(FileDownloadButton).props().href).toEqual("/touchstones/v1/responsibilities/csv/");
         expect(rendered.find(ResponsibilitySet)).toHaveLength(2);
     });
 

--- a/config/api_version
+++ b/config/api_version
@@ -1,1 +1,1 @@
-master
+VIMC-4737

--- a/config/api_version
+++ b/config/api_version
@@ -1,1 +1,1 @@
-VIMC-4737
+master


### PR DESCRIPTION
To test:
- Run admin app and visit the responsibilities page for a touchstone version e.g. http://localhost:5000/admin/touchstones/op-2018/op-2018-1/responsibilities/
- Optionally add some comments to the responsibility set and/or its responsibilities
- Optionally upload some burden estimates via contrib app
  - See [central-burden-template.op-2018-1.yf-routine.partial.csv](https://github.com/vimc/montagu-webapps/files/6960042/central-burden-template.op-2018-1.yf-routine.partial.csv) for a burden estimate set with two missing estimates
- Click the "Responsibilities summary" button
- Example output: [responsibilities_op-2018-1.csv](https://github.com/vimc/montagu-webapps/files/6967421/responsibilities_op-2018-1.csv)

Notes:
- Depends on vimc/montagu-api#461

To-do:
- [x] Revert `montagu-api` to master