### PR TITLE
VIMC-4814 Hide wide format coverage for cholera and typhoid

### DIFF
--- a/app/src/main/shared/settings/default.ts
+++ b/app/src/main/shared/settings/default.ts
@@ -15,7 +15,7 @@ export const settings: Settings = {
         return !this.nonStochasticTouchstones.some((ts: string) => touchstoneId.indexOf(ts) === 0);
     },
     hideWideFormat: function (disease) {
-        return ["MenA", "JE", "YF", "HPV", "measles", "rubella"]
+        return ["MenA", "JE", "YF", "HPV", "measles", "rubella", "cholera", "typhoid"]
             .map(d => d.toLocaleLowerCase())
             .indexOf(disease.toLowerCase()) > -1
     },

--- a/app/src/test/contrib/components/Responsibilities/Coverage/DownloadCoverageContentTests.tsx
+++ b/app/src/test/contrib/components/Responsibilities/Coverage/DownloadCoverageContentTests.tsx
@@ -148,17 +148,20 @@ describe("Download Coverage Content Component", () => {
     });
 
     it("does not show format control for prohibited diseases", () => {
+        const expectFormatControlNotShownForDisease = (disease: string) => {
+            const rendered = shallow(<DownloadCoverageContentComponent
+                coverageSets={[testCoverageSet]}
+                group={testGroup}
+                scenario={{...testScenario, disease}}
+                selectedFormat={"long"}
+                setFormat={() => {
+                }}
+                touchstone={testTouchstone}/>);
 
-        const rendered = shallow(<DownloadCoverageContentComponent
-            coverageSets={[testCoverageSet]}
-            group={testGroup}
-            scenario={{...testScenario, disease: "measles"}}
-            selectedFormat={"long"}
-            setFormat={() => {
-            }}
-            touchstone={testTouchstone}/>);
-
-        expect(rendered.find(FormatControl).length).toEqual(0);
+            expect(rendered.find(FormatControl).length).toEqual(0);
+        };
+        ["MenA", "JE", "YF", "HPV", "measles", "rubella", "cholera", "typhoid"]
+            .forEach((disease: string) => expectFormatControlNotShownForDisease(disease));
     });
 
     it("filterToExpectations is selected by default", () => {


### PR DESCRIPTION
Adds cholera and typhoid to the list of diseases for which wide format coverage is hidden in the Contribution portal. 
Also expands the test of the hidden format control to include all diseases in the list. 

This branch is deployed to UAT, and the easiest way to test it is on there. Add yourself to relevant modelling groups through the Admin portal. You should see that Typhoid and Cholera are now included in those diseases where browsing to touchstone / Download coverage data does not show a format picker. Download should provide long format (a row for each year). Contrast the view for disease not included in this list, e.g. Rota, where format picker should be shown

Example modelling groups:
Typhoid: Yale (Ginny Pitzer)
Cholera: IVI (Jong Hoon-Kim)
Rota: Emory University (Ben Lopman)