### PR TITLE
Update demography text - make general

### DIFF
--- a/app/src/main/shared/components/Demographics/DownloadDemographicsContent.tsx
+++ b/app/src/main/shared/components/Demographics/DownloadDemographicsContent.tsx
@@ -29,10 +29,10 @@ export class DownloadDemographicsContentComponent extends React.Component<Downlo
 
         const defaultDescription = <div>
             <p>
-                All available datasets are based on the UNWPP 2019 release, with the
+                All available datasets are based on UNWPP, with the
                 exception of neonatal (28 day) mortality which is a hybrid between the
                 UNWPP infant mortality (available 1950 to 2100) and neonatal mortality
-                from IGME/childmortality.org, released in September 2019.
+                from IGME/childmortality.org.
             </p>
             <p>
                 Select the following options to download a CSV file containing

--- a/app/src/test/shared/components/Demographics/DownloadDemographicContentTests.tsx
+++ b/app/src/test/shared/components/Demographics/DownloadDemographicContentTests.tsx
@@ -69,7 +69,7 @@ describe("Download Demographic Content Component", () => {
             const rendered = shallow(<DownloadDemographicsContent/>, {context: {store}}).dive().dive();
             expect(rendered.find("div.sectionTitle").text()).toEqual(`Demographic data for ${testTouchstone.description}`);
             expect(rendered.find(DemographicOptions).length).toEqual(1);
-            expect(rendered.text().indexOf("All available datasets are based on the UNWPP 2019 release")).toBeGreaterThan(-1);
+            expect(rendered.text().indexOf("All available datasets are based on UNWPP")).toBeGreaterThan(-1);
             expect(rendered.text().indexOf("All available datasets pertain only to the anonymous pre-defined country")).toEqual(-1);
         }
     );
@@ -89,7 +89,7 @@ describe("Download Demographic Content Component", () => {
         expect(rendered.find("div.sectionTitle").text()).toEqual(`Demographic data for ${touchstone.description}`);
         expect(rendered.find(DemographicOptions).length).toEqual(1);
         expect(rendered.text().indexOf("All available datasets pertain only to the anonymous pre-defined country")).toBeGreaterThan(-1);
-        expect(rendered.text().indexOf("All available datasets are based on the UNWPP 2019 release")).toEqual(-1);
+        expect(rendered.text().indexOf("All available datasets are based on UNWPP")).toEqual(-1);
     });
 
 });


### PR DESCRIPTION
This PR makes the text on the demographic download page a bit more general, removing the explicit year, to avoid "2019" appearing on the new page that users will see when downloading the 2022 demography (see [vimc-7116 branch in montagu-imports](https://github.com/vimc/montagu-imports/pull/167)

Perhaps at some point we could make it so that we can vary this message depending on demographic dataset...

I'm not sure whether there is a verson no. that needs bumping...?